### PR TITLE
GREEN-21: remove unused tx parameter from get_tx_timestamp

### DIFF
--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -999,7 +999,7 @@ class Shardus extends EventEmitter {
         /* prettier-ignore */
         if (logFlags.p2pNonFatal && logFlags.console) console.log("Dapp request to generate a new timestmap for the tx");
       }
-      timestampReceipt = await this.stateManager.transactionConsensus.askTxnTimestampFromNode(tx, txId);
+      timestampReceipt = await this.stateManager.transactionConsensus.askTxnTimestampFromNode(txId);
       /* prettier-ignore */
       if (logFlags.p2pNonFatal && logFlags.console) console.log("Network generated a" +
         " timestamp", txId, timestampReceipt);

--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -917,10 +917,7 @@ class TransactionConsenus {
     if (logFlags.debug) this.mainLogger.debug(`Pruned tx timestamp cache.`)
   }
 
-  async askTxnTimestampFromNode(
-    tx: Shardus.OpaqueTransaction,
-    txId: string
-  ): Promise<Shardus.TimestampReceipt | null> {
+  async askTxnTimestampFromNode(txId: string): Promise<Shardus.TimestampReceipt | null> {
     const homeNode = ShardFunctions.findHomeNode(
       Context.stateManager.currentCycleShardData.shardGlobals,
       txId,


### PR DESCRIPTION
https://linear.app/shm/issue/GREEN-21/remove-the-unused-tx-parameter-in-the-get-tx-timestamp-handler-and

Remove unused `tx` parameter from `get_tx_timestamp`