### PR TITLE
RED-64/65: Remove golden ticket specific logic when adding nodes to standby map

### DIFF
--- a/src/p2p/Join/v2/index.ts
+++ b/src/p2p/Join/v2/index.ts
@@ -88,15 +88,6 @@ export function saveJoinRequest(joinRequest: JoinRequest, persistImmediately = f
     return
   }
 
-  // if golden ticket is enabled, add nodes with adminCert + golden ticket to standbyNodesInfo immediately
-  if (
-    shardus.config.p2p.goldenTicketEnabled === true &&
-    joinRequest.appJoinData?.adminCert?.goldenTicket === true
-  ) {
-    addJoinRequestToStandbyMap(joinRequest)
-    return
-  }
-
   newJoinRequests.push(joinRequest)
 }
 


### PR DESCRIPTION
https://linear.app/shm/issue/RED-65/secondary-issue-problems-removing-standby-nodes-mentioned-in-logs
https://linear.app/shm/issue/RED-64/nodes-fail-to-fetch-cycles-in-betanext

Summary: GT'd nodes should go through the regular process of getting added to newJoinRequest instead of getting added directly to standby map. 