### PR TITLE
RED-47: Adjust debugMiddleware to use time based counter

### DIFF
--- a/src/network/debugMiddleware.ts
+++ b/src/network/debugMiddleware.ts
@@ -38,12 +38,11 @@ function handleDebugAuth(_req, res, next, authLevel) {
               })
             }
           } else {
-            console.log('Signature is not correct', sigObj, currentCounter)
+            console.log('Signature is not correct')
           }
         } else {
           console.log(
             'Counter is more than 10 seconds old or less than last counter. Counter: ',
-            sigObj,
             currentCounter,
             'last counter:',
             lastCounter


### PR DESCRIPTION
https://linear.app/shm/issue/RED-47/remove-lock-of-debug-access-in-validator-if-max-value-was-submitted-as

Summary: Cap counter it so that you can only go to max of ~10 seconds in the future 