### PR TITLE
GREEN-37: check possible duplicate signatures while validating receipt in function validateReceipt

### DIFF
--- a/src/p2p/GlobalAccounts.ts
+++ b/src/p2p/GlobalAccounts.ts
@@ -306,7 +306,17 @@ function validateReceipt(receipt: P2P.GlobalAccountsTypes.Receipt) {
   }
   // Make a map of signs that overlap with consensusGroup
   const signsInConsensusGroup: P2P.P2PTypes.Signature[] = []
+  const uniqueSignOwnerMap = {}
+
   for (const sign of receipt.signs) {
+    const owner = sign.owner.toLowerCase()
+    if (uniqueSignOwnerMap[owner]) {
+      if (logFlags.console)
+        console.log(`validateReceipt: duplicate signatures for owner ${utils.stringifyReduce(sign.owner)}`)
+      continue
+    }
+    uniqueSignOwnerMap[owner] = true
+
     /** [TODO] [AS] Replace with NodeList.byPubKey.get() */
     // const node = p2p.state.getNodeByPubKey(sign.owner)
     const node = NodeList.byPubKey.get(sign.owner)


### PR DESCRIPTION
https://linear.app/shm/issue/GREEN-37/validatereceipt-in-globalaccountstx-does-not-check-for-duplicate

check possible duplicate signatures while validating receipt in function validateReceipt