### PR TITLE
Add route to check if archiver is joined

### DIFF
--- a/src/p2p/Archivers.ts
+++ b/src/p2p/Archivers.ts
@@ -63,12 +63,6 @@ export enum DataRequestTypes {
   UNSUBSCRIBE = 'UNSUBSCRIBE',
 }
 
-export enum ReceiptsBundleByInterval {
-  '30SECS_DATA',
-  '20SECS_DATA',
-  '10SECS_DATA',
-}
-
 // This is to check if the new archiver data subscriptions feature is activated in shardeum v1.1.3
 // We can remove later after v1.1.3 upgrade
 export let archiverDataSubscriptionsUpdateFeatureActivated = false

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -925,9 +925,8 @@ class TransactionQueue {
             if (!queueEntry) return res.status(400).json({ success: false, reason: 'Receipt Not Found.' })
             if (full_receipt) {
               const fullReceipt: ArchiverReceipt = this.getArchiverReceiptFromQueueEntry(queueEntry)
-              if (fullReceipt === null)
-                result = JSON.parse(utils.cryptoStringify({ success: true, receipt: fullReceipt }))
-              result = { success: false, reason: 'Receipt Not Found.' }
+              if (fullReceipt === null) return res.status(400).json({ success: false, reason: 'Receipt Not Found.' })
+              result = JSON.parse(utils.cryptoStringify({ success: true, receipt: fullReceipt }))
             } else {
               result = { success: true, receipt: this.stateManager.getReceipt2(queueEntry) }
             }


### PR DESCRIPTION
https://linear.app/shm/issue/BLUE-9/check-archiver-join-status-using-the-joinedarchiver-endpoint

Summary:
Add an endpoint `/joinedArchiver/:publicKey`, which checks whether the provided archiver is joined to the network or not