### PR TITLE
RED-95: Make safetyMode and safetyNum cycle record validation optional

### DIFF
--- a/src/p2p/Sync.ts
+++ b/src/p2p/Sync.ts
@@ -559,8 +559,8 @@ function validateCycles(cycles: P2P.CycleCreatorTypes.CycleRecord[]) {
   }
   for (const cycleRecord of cycles) {
     let err = validateTypes(cycleRecord, {
-      safetyMode: 'b',
-      safetyNum: 'n',
+      safetyMode: 'b?',
+      safetyNum: 'n?',
       networkStateHash: 's',
       refreshedArchivers: 'a',
       refreshedConsensors: 'a',


### PR DESCRIPTION
https://linear.app/shm/issue/RED-95/investigate-if-we-can-remove-safetymode-field

Summary: Make safetyMode and safetyNum cycle record validation optional