### PR TITLE
BLUE-68(fix): targetCount calculation for 'restore' mode

### DIFF
--- a/src/p2p/CycleAutoScale.ts
+++ b/src/p2p/CycleAutoScale.ts
@@ -412,12 +412,13 @@ function setAndGetTargetCount(prevRecord: P2P.CycleCreatorTypes.CycleRecord): nu
     } else if (
       // In these modes, the target count should be set to the desired/min count
       prevRecord.mode === 'safety' ||
-      prevRecord.mode === 'recovery' ||
       prevRecord.mode === 'restore'
     ) {
       // For the number of nodes to be added in each cycle during these modes is defined in the calculateToAcceptV2 function
       // using minNodes here since target is what will be used to get into processing mode
       targetCount = config.p2p.minNodes
+    } else if (prevRecord.mode === 'recovery') {
+      targetCount = config.p2p.minNodes + config.p2p.extraNodesToAddInRestart
     } else if (prevRecord.mode === 'restart') {
       // In restart mode, all the nodes remain in 'selected?' mode until the desired number of nodes are reached
       /* prettier-ignore */ if (logFlags && logFlags.verbose) console.log("CycleAutoScale: in restart")


### PR DESCRIPTION
### Issue

The Standby nodes were not being allowed to join the network as the [target count was strictly set equal to the minNodes value](https://github.com/shardeum/shardus-core/blob/dev/src/p2p/CycleAutoScale.ts#L420), whereas in order to enter Restore mode from Recovery mode the network needs **`extraNodesToAddInRestart`** nodes in [addition to the active + syncing nodes](https://github.com/shardeum/shardus-core/blob/dev/src/p2p/Modes.ts#L249).


To allow these many nodes to join the targetCount needs to be set to `config.p2p.minNodes + config.p2p.extraNodesToAddInRestart.standby`