### PR TITLE
Influencer mode fix 1.

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -315,7 +315,8 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     stuckTxRemoveTime: 1000 * 60 * 2, // 2 minutes
     removeStuckChallengedTXs: true,
     receiptRemoveFix: true,
-    stuckTxQueueFix: true
+    stuckTxQueueFix: true,
+    singleAccountStuckFix: false
   },
   sharding: { nodesPerConsensusGroup: 5, nodesPerEdge: 2, executeInOneShard: false },
   mode: ServerMode.Debug,

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -1236,6 +1236,8 @@ export interface ServerConfiguration {
     receiptRemoveFix: boolean
     // fix for stuck txs in the queue
     stuckTxQueueFix: boolean
+    // fix for stuck txs for single account tests
+    singleAccountStuckFix: boolean
   }
   /** Options for sharding calculations */
   sharding?: {


### PR DESCRIPTION
Instead of changing other tx states to `await final data`, now we will change only if the current tx  state is `consensing` and it has seen a vote for 10s but still unable to produce or  get a receipt2.  This is possible if a node
- miss  confirm gossips
- fail in robustQueries
- miss  receipt2+data  gossip