### PR TITLE
Influencer mode fix 2

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -315,7 +315,8 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     stuckTxRemoveTime: 1000 * 60 * 2, // 2 minutes
     removeStuckChallengedTXs: true,
     receiptRemoveFix: true,
-    stuckTxQueueFix: true
+    stuckTxQueueFix: true,
+    oldTXStateChanges: false
   },
   sharding: { nodesPerConsensusGroup: 5, nodesPerEdge: 2, executeInOneShard: false },
   mode: ServerMode.Debug,

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -1236,6 +1236,8 @@ export interface ServerConfiguration {
     receiptRemoveFix: boolean
     // fix for stuck txs in the queue
     stuckTxQueueFix: boolean
+    // just use old tx state changes
+    oldTXStateChanges: boolean
   }
   /** Options for sharding calculations */
   sharding?: {

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -2077,7 +2077,7 @@ class TransactionQueue {
               txQueueEntry.acceptedTx.txId,
               txQueueEntry.acceptedTx.timestamp
             )
-          }                    
+          }
 
           const minNodesToVote = 3
           const voterPercentage = configContext.stateManager.voterPercentage
@@ -2089,13 +2089,13 @@ class TransactionQueue {
           txQueueEntry.eligibleNodeIdsToVote = new Set(
             txQueueEntry.executionGroup.slice(0, numberOfVoters).map((node) => node.id)
           )
-          
+
           // confirm nodes are lowest ranked nodes
           txQueueEntry.eligibleNodeIdsToConfirm = new Set(
             txQueueEntry.executionGroup
               .slice(txQueueEntry.executionGroup.length - numberOfVoters)
               .map((node) => node.id)
-          )          
+          )
 
           const ourID = this.stateManager.currentCycleShardData.ourNode.id
           for (let idx = 0; idx < txQueueEntry.executionGroup.length; idx++) {
@@ -2105,7 +2105,7 @@ class TransactionQueue {
             if (node.id === ourID) {
               txQueueEntry.ourExGroupIndex = idx
               this.seqLogger.info(`0x53455105 ${shardusGetTime()} tx:${txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: executor index ${txQueueEntry.ourExGroupIndex}:${(node as Shardus.NodeWithRank).rank}`)
-            }            
+            }
           }
           if (txQueueEntry.eligibleNodeIdsToConfirm.has(Self.id)) {
             this.seqLogger.info(`0x53455105 ${shardusGetTime()} tx:${txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: confirmator`)
@@ -2302,10 +2302,10 @@ class TransactionQueue {
                       this.stateManager.config.p2p.spreadTxToGroupSyncingBinary
                     ) {
                       if (logFlags.seqdiagram) {
-                        for (const node of this.stateManager.currentCycleShardData.syncingNeighborsTxGroup) {                
+                        for (const node of this.stateManager.currentCycleShardData.syncingNeighborsTxGroup) {
                           this.seqLogger.info(`0x53455102 ${shardusGetTime()} tx:${acceptedTx.txId} ${NodeList.activeIdToPartition.get(Self.id)}-->>${NodeList.activeIdToPartition.get(node.id)}: ${'spread_tx_to_group_syncing'}`)
                         }
-                      }                      
+                      }
                       const request = acceptedTx as SpreadTxToGroupSyncingReq
                       this.p2p.tellBinary<SpreadTxToGroupSyncingReq>(
                         this.stateManager.currentCycleShardData.syncingNeighborsTxGroup,
@@ -3896,20 +3896,20 @@ class TransactionQueue {
   async broadcastState(
     nodes: Shardus.Node[],
     message: { stateList: Shardus.WrappedResponse[]; txid: string },
-    context: string 
+    context: string
   ): Promise<void> {
     if (this.config.p2p.useBinarySerializedEndpoints && this.config.p2p.broadcastStateBinary) {
       // convert legacy message to binary supported type
-      const request = message as BroadcastStateReq  
+      const request = message as BroadcastStateReq
       if (logFlags.seqdiagram) {
-        for (const node of nodes) {                        
+        for (const node of nodes) {
           if (context == "tellCorrespondingNodes") {
             this.seqLogger.info(`0x53455102 ${shardusGetTime()} tx:${message.txid} ${NodeList.activeIdToPartition.get(Self.id)}-->>${NodeList.activeIdToPartition.get(node.id)}: ${'broadcast_state_nodes'}`)
           } else {
             this.seqLogger.info(`0x53455102 ${shardusGetTime()} tx:${message.txid} ${NodeList.activeIdToPartition.get(Self.id)}-->>${NodeList.activeIdToPartition.get(node.id)}: ${'broadcast_state_neighbour'}`)
-          }        
+          }
         }
-      }          
+      }
       this.p2p.tellBinary<BroadcastStateReq>(
         nodes,
         InternalRouteEnum.binary_broadcast_state,
@@ -4429,11 +4429,11 @@ class TransactionQueue {
             // convert legacy message to binary supported type
             const request = message as BroadcastFinalStateReq
             if (logFlags.seqdiagram) {
-              for (const node of filterdCorrespondingAccNodes) {                
+              for (const node of filterdCorrespondingAccNodes) {
                 this.seqLogger.info(`0x53455102 ${shardusGetTime()} tx:${message.txid} ${NodeList.activeIdToPartition.get(Self.id)}-->>${NodeList.activeIdToPartition.get(node.id)}: ${'broadcast_finalstate'}`)
               }
             }
-            
+
             this.p2p.tellBinary<BroadcastFinalStateReq>(
               filterdCorrespondingAccNodes,
               InternalRouteEnum.binary_broadcast_finalstate,
@@ -4630,7 +4630,7 @@ class TransactionQueue {
   async processTransactions(firstTime = false): Promise<void> {
     const seenAccounts: SeenAccounts = {}
     let pushedProfilerTag = null
-    const startTime = shardusGetTime()        
+    const startTime = shardusGetTime()
 
     const processStats: ProcessQueueStats = {
       totalTime: 0,
@@ -5123,28 +5123,30 @@ class TransactionQueue {
           }
 
           if (txAge > timeM3 + configContext.stateManager.confirmationSeenExpirationTime + 10000) {
-            nestedCountersInstance.countEvent('txExpired', `txAge > timeM3 + confirmSeenExpirationTime + 10s`)
-            // maybe we missed the spread_appliedReceipt2 gossip, go to await final data if we have a confirmation
-            // we will request the final data (and probably receipt2)
-            if (configContext.stateManager.disableTxExpiration && hasSeenVote) {
-              nestedCountersInstance.countEvent('txExpired', `> timeM3 + confirmSeenExpirationTime state: ${queueEntry.state} hasSeenVote: ${hasSeenVote} hasSeenConfirmation: ${hasSeenConfirmation} waitForReceiptOnly: ${queueEntry.waitForReceiptOnly}`)
-              if(this.config.stateManager.txStateMachineChanges){
-                if (configContext.stateManager.stuckTxQueueFix) {
-                  // make sure we are not resetting the state and causing state start timestamp to be updated repeatedly
-                  if (queueEntry.state !== 'await final data' && queueEntry.state !== 'await repair') this.updateTxState(queueEntry, 'await' +
-                    ' final data')
-                } else {
-                  this.updateTxState(queueEntry, 'await final data', 'processTx4')
-                }
+            if (configContext.stateManager.oldTXStateChanges === false) {
+              nestedCountersInstance.countEvent('txExpired', `txAge > timeM3 + confirmSeenExpirationTime + 10s`)
+              // maybe we missed the spread_appliedReceipt2 gossip, go to await final data if we have a confirmation
+              // we will request the final data (and probably receipt2)
+              if (configContext.stateManager.disableTxExpiration && hasSeenVote) {
+                nestedCountersInstance.countEvent('txExpired', `> timeM3 + confirmSeenExpirationTime state: ${queueEntry.state} hasSeenVote: ${hasSeenVote} hasSeenConfirmation: ${hasSeenConfirmation} waitForReceiptOnly: ${queueEntry.waitForReceiptOnly}`)
+                if(this.config.stateManager.txStateMachineChanges){
+                  if (configContext.stateManager.stuckTxQueueFix) {
+                    // make sure we are not resetting the state and causing state start timestamp to be updated repeatedly
+                    if (queueEntry.state !== 'await final data' && queueEntry.state !== 'await repair') this.updateTxState(queueEntry, 'await' +
+                      ' final data')
+                  } else {
+                    this.updateTxState(queueEntry, 'await final data', 'processTx4')
+                  }
 
-              } else {
-                this.updateTxState(queueEntry, 'consensing')
+                } else {
+                  this.updateTxState(queueEntry, 'consensing')
+                }
+                if (configContext.stateManager.stuckTxQueueFix === false) continue // we should not skip this TX
               }
-              if (configContext.stateManager.stuckTxQueueFix === false) continue // we should not skip this TX
-            }
-            if (configContext.stateManager.disableTxExpiration === false) {
-              this.setTXExpired(queueEntry, currentIndex, 'txAge > timeM3 + confirmSeenExpirationTime + 10s')
-              continue
+              if (configContext.stateManager.disableTxExpiration === false) {
+                this.setTXExpired(queueEntry, currentIndex, 'txAge > timeM3 + confirmSeenExpirationTime + 10s')
+                continue
+              }
             }
           } else if (txAge > timeM3 + configContext.stateManager.confirmationSeenExpirationTime) {
             let shouldExpire = true
@@ -5325,7 +5327,7 @@ class TransactionQueue {
                 // this.updateTxState(queueEntry, 'await final data')
               } else {
                 this.updateTxState(queueEntry, 'await final data', 'processTx5')
-              } 
+              }
             }
 
             this.processQueue_markAccountsSeen(seenAccounts, queueEntry)
@@ -5410,7 +5412,7 @@ class TransactionQueue {
                 if (logFlags.seqdiagram) this.seqLogger.info(`0x53455104 ${shardusGetTime()} tx:${queueEntry.acceptedTx.txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: upstream:null`)
                 nestedCountersInstance.countEvent('processing', 'busy waiting the upstream tx.' +
                   ' but it is null')
-              } else {                
+              } else {
                 if (upstreamTx.logID === queueEntry.logID) {
                   if (logFlags.seqdiagram) this.seqLogger.info(`0x53455104 ${shardusGetTime()} tx:${queueEntry.acceptedTx.txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: upstream:same`)
                   nestedCountersInstance.countEvent('processing', 'busy waiting the upstream tx but it is same txId')
@@ -7544,10 +7546,10 @@ class TransactionQueue {
     if (this.archivedQueueEntriesByID.has(txId)) delete this.archivedQueueEntriesByID[txId]
   }
   updateTxState(queueEntry: QueueEntry, nextState: string, context = ''): void {
-    if (logFlags.seqdiagram) 
+    if (logFlags.seqdiagram)
       if (context == '')
         this.seqLogger.info(`0x53455104 ${shardusGetTime()} tx:${queueEntry.acceptedTx.txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: ${queueEntry.state}-${nextState}`)
-      else 
+      else
         this.seqLogger.info(`0x53455104 ${shardusGetTime()} tx:${queueEntry.acceptedTx.txId} Note over ${NodeList.activeIdToPartition.get(Self.id)}: ${queueEntry.state}-${nextState}:${context}`)
     const currentState = queueEntry.state
     this.txDebugMarkEndTime(queueEntry, currentState)


### PR DESCRIPTION
This approach fix the stuck txs by simply avoiding time dependent  state change to `await final data`. Although this work in current situation, there is a non-zero chance that a node may stuck in `consensing` state due to:
- miss confirm gossips
- fail in robustQueries
- miss receipt2+data gossip