### PR TITLE
Out of memory bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shardus/core",
-  "version": "2.12.30-53",
+  "version": "2.12.30-54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shardus/core",
-      "version": "2.12.30-53",
+      "version": "2.12.30-54",
       "dependencies": {
         "@hapi/sntp": "3.1.1",
         "@mapbox/node-pre-gyp": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shardus/core",
-  "version": "2.12.30-53",
+  "version": "2.12.30-54",
   "engines": {
     "node": "18.16.1"
   },

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -2304,10 +2304,10 @@ class Shardus extends EventEmitter {
       }
 
       if (typeof application.transactionReceiptPass === 'function') {
-        applicationInterfaceImpl.transactionReceiptPass = async (tx, wrappedStates, applyResponse) =>
-          application.transactionReceiptPass(tx, wrappedStates, applyResponse)
+        applicationInterfaceImpl.transactionReceiptPass = async (tx, wrappedStates, applyResponse, isExecutionGroup) =>
+          application.transactionReceiptPass(tx, wrappedStates, applyResponse, isExecutionGroup)
       } else {
-        applicationInterfaceImpl.transactionReceiptPass = async function (tx, wrappedStates, applyResponse) {}
+        applicationInterfaceImpl.transactionReceiptPass = async function (tx, wrappedStates, applyResponse, isExecutionGroup) {}
       }
 
       if (typeof application.transactionReceiptFail === 'function') {

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -235,8 +235,9 @@ export interface App {
    * This is called after consensus has received or produced a receipt and the trasaction is approved.
    * Do not change any of the values passes in.
    * This is a place to generate other transactions, or do off chain work like send and email.
+   * isExecutionGroup: boolean  this is set to true if we are in the execution group
    */
-  transactionReceiptPass?: (inTx: OpaqueTransaction, wrappedStates: any, applyResponse: ApplyResponse) => void
+  transactionReceiptPass?: (inTx: OpaqueTransaction, wrappedStates: any, applyResponse: ApplyResponse, isExecutionGroup: boolean) => void
 
   /**
    * This is called after consensus has received or produced a receipt and the trasaction fails.

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -6215,6 +6215,9 @@ class TransactionQueue {
                   )
                   /* prettier-ignore */ this.setDebugLastAwaitedCall( 'this.stateManager.transactionConsensus.checkAndSetAccountData()', DebugComplete.Completed )
                   queueEntry.accountDataSet = true
+                  // endpoint to allow dapp to execute something that depends on a transaction being approved.
+                  this.app.transactionReceiptPass(queueEntry.acceptedTx.data, queueEntry.collectedFinalData, queueEntry?.preApplyTXResult?.applyResponse)
+                  /* prettier-ignore */ if (logFlags.verbose) console.log('transactionReceiptPass', queueEntry.acceptedTx.txId, queueEntry)
                   this.updateSimpleStatsObject(
                     processStats.awaitStats,
                     'checkAndSetAccountData',

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -1631,8 +1631,8 @@ class TransactionQueue {
       this.profiler.profileSectionEnd('commit-2-addAccountStatesAndTX')
       this.profiler.profileSectionStart('commit-3-transactionReceiptPass')
       // endpoint to allow dapp to execute something that depends on a transaction being approved.
-      this.app.transactionReceiptPass(acceptedTX.data, wrappedStates, applyResponse)
-      /* prettier-ignore */ if (logFlags.verbose) console.log('transactionReceiptPass', acceptedTX.txId, queueEntry)
+      this.app.transactionReceiptPass(acceptedTX.data, wrappedStates, applyResponse, true)
+      /* prettier-ignore */ if (logFlags.verbose) console.log('transactionReceiptPass 2', acceptedTX.txId, queueEntry)
 
       this.profiler.profileSectionEnd('commit-3-transactionReceiptPass')
     } catch (ex) {
@@ -6216,8 +6216,8 @@ class TransactionQueue {
                   /* prettier-ignore */ this.setDebugLastAwaitedCall( 'this.stateManager.transactionConsensus.checkAndSetAccountData()', DebugComplete.Completed )
                   queueEntry.accountDataSet = true
                   // endpoint to allow dapp to execute something that depends on a transaction being approved.
-                  this.app.transactionReceiptPass(queueEntry.acceptedTx.data, queueEntry.collectedFinalData, queueEntry?.preApplyTXResult?.applyResponse)
-                  /* prettier-ignore */ if (logFlags.verbose) console.log('transactionReceiptPass', queueEntry.acceptedTx.txId, queueEntry)
+                  this.app.transactionReceiptPass(queueEntry.acceptedTx.data, queueEntry.collectedFinalData, queueEntry?.preApplyTXResult?.applyResponse, false)
+                  /* prettier-ignore */ if (logFlags.verbose) console.log('transactionReceiptPass 1', queueEntry.acceptedTx.txId, queueEntry)
                   this.updateSimpleStatsObject(
                     processStats.awaitStats,
                     'checkAndSetAccountData',


### PR DESCRIPTION
# The bug

In the commitConsensedTransaction, we call app.transactionReceiptPass() and it removes the tx from the ShardeumState. But, commitConsensedTransaction is ran only for the execution grouup nodes. Tx group nodes update the account states via a different path (i.e. 'await final data' -> checkAndSetAccountData). So, the txs keep piling up in the tx group nodes because we never cleared for them

# Fix

It is quite simple fix that we just have to call transactionReceiptPass() for the tx group nodes in the `await final data` state.