### PR TITLE
RED-140: fix `/debug` endpoint crash on windows

### DIFF
--- a/src/debug/debug.ts
+++ b/src/debug/debug.ts
@@ -5,6 +5,7 @@ import zlib from 'zlib'
 import Trie from 'trie-prefix-tree'
 import { isDebugModeMiddleware, isDebugModeMiddlewareMedium } from '../network/debugMiddleware'
 import { nestedCountersInstance } from '../utils/nestedCounters'
+import { logFlags } from '../logger'
 const tar = require('tar-fs')
 const fs = require('fs')
 
@@ -34,7 +35,7 @@ class Debug {
     const cwd = process.cwd()
     const filesRel = {}
     for (const src in this.files) {
-      const srcRel = path.relative(cwd, src)
+      const srcRel = path.relative(cwd, src).replace(/\\/g, '/')
       const dest = this.files[src]
       filesRel[srcRel] = dest
     }
@@ -43,15 +44,29 @@ class Debug {
     const pack = tar.pack(cwd, {
       entries,
       map: function (header) {
+        let entry = header.name.replace(/\\/g, '/')
         // Find the closest entry for this item
-        let entry = header.name
-        while (!trie.isPrefix(entry)) {
+        while (!trie.isPrefix(entry) && entry.length > 0) {
           entry = entry.slice(0, -1)
+        }
+        if (entry.length === 0) {
+          if (logFlags.error) {
+            nestedCountersInstance.countEvent('debug', 'error: No valid entry found for header')
+            this.main.logger.error('debug: No valid entry found for header:', header.name)
+          }
+          return header 
         }
         // Remove srcRel from header.name
         header.name = path.relative(entry, header.name)
         // Prefix dest to whatever remains
         const dest = filesRel[entry]
+        if (!dest) {
+          if (logFlags.error) {
+            nestedCountersInstance.countEvent('debug', 'error: Destination not found for entry')
+            this.main.logger.error('debug: Destination not found for entry:', entry)
+          }
+          return header 
+        }
         header.name = path.normalize(path.join(dest, header.name))
         return header
       },

--- a/src/types/CompareCertResp.ts
+++ b/src/types/CompareCertResp.ts
@@ -32,6 +32,7 @@ export const deserializeCompareCertResp = (stream: VectorBufferStream): CompareC
   const obj: CompareCertRespSerializable = Utils.safeJsonParse(stream.readString())
 
   const errors = verifyPayload(AJVSchemaEnum.CompareCertResp, obj)
+
   if (errors && errors.length > 0) {
     throw new Error('Data validation error')
   }

--- a/src/types/GetTxTimestampResp.ts
+++ b/src/types/GetTxTimestampResp.ts
@@ -93,6 +93,7 @@ export function deserializeGetTxTimestampResp(stream: VectorBufferStream): getTx
   }
 
   const errors = verifyPayload(AJVSchemaEnum.GetTxTimestampResp, result)
+
   if (errors && errors.length > 0) {
     throw new Error('Data validation error')
   }

--- a/src/types/SignAppDataReq.ts
+++ b/src/types/SignAppDataReq.ts
@@ -1,5 +1,7 @@
 import { stateManager } from '../p2p/Context'
 import { VectorBufferStream } from '../utils/serialization/VectorBufferStream'
+import { verifyPayload } from './ajv/Helpers'
+import { AJVSchemaEnum } from './enum/AJVSchemaEnum'
 import { AppObjEnum } from './enum/AppObjEnum'
 import { TypeIdentifierEnum } from './enum/TypeIdentifierEnum'
 
@@ -28,10 +30,15 @@ export function deserializeSignAppDataReq(stream: VectorBufferStream): SignAppDa
   if (version > cSignAppDataReqVersion) {
     throw new Error(`SignAppDataReq version mismatch, version: ${version}`)
   }
-  return {
+  const result = {
     type: stream.readString(),
     nodesToSign: stream.readUInt8(),
     hash: stream.readString(),
     appData: stateManager.app.binaryDeserializeObject(AppObjEnum.AppData, stream.readBuffer()),
   }
+  const errors = verifyPayload(AJVSchemaEnum.SignAppDataReq, result)
+  if (errors && errors.length > 0) {
+    throw new Error('Data validation error')
+  }
+  return result
 }

--- a/src/types/SignAppDataResp.ts
+++ b/src/types/SignAppDataResp.ts
@@ -1,4 +1,6 @@
 import { VectorBufferStream } from '../utils/serialization/VectorBufferStream'
+import { verifyPayload } from './ajv/Helpers'
+import { AJVSchemaEnum } from './enum/AJVSchemaEnum'
 import { TypeIdentifierEnum } from './enum/TypeIdentifierEnum'
 
 export const cSignAppDataRespVersion = 1
@@ -30,11 +32,16 @@ export function deserializeSignAppDataResp(stream: VectorBufferStream): SignAppD
   if (version > cSignAppDataRespVersion) {
     throw new Error(`SignAppDataResp version mismatch, version: ${version}`)
   }
-  return {
+  const result = {
     success: stream.readUInt8() === 1,
     signature: {
       owner: stream.readString(),
       sig: stream.readString(),
     },
   }
+  const errors = verifyPayload(AJVSchemaEnum.SignAppDataResp, result)
+  if (errors && errors.length > 0) {
+    throw new Error('Data validation error')
+  }
+  return result
 }

--- a/src/types/ajv/Helpers.ts
+++ b/src/types/ajv/Helpers.ts
@@ -42,6 +42,8 @@ import { initGetAccountQueueCountResp } from './GetAccountQueueCountResp'
 import { initMakeReceiptReq } from './MakeReceiptReq'
 import { initGetTrieHashesReq } from './GetTrieHashesReq'
 import { initGetTrieHashesResp } from './GetTrieHashesResp'
+import { initSignAppDataReq } from './SignAppDataReq'
+import { initSignAppDataResp } from './SignAppDataResp'
 import { initCachedAppData } from './CachedAppData'
 import { initSendCachedAppDataReq } from './sendCachedAppDataReq'
 import { AJVSchemaEnum } from '../enum/AJVSchemaEnum'
@@ -88,6 +90,8 @@ export function initAjvSchemas(): void {
   initMakeReceiptReq()
   initGetTrieHashesReq()
   initGetTrieHashesResp()
+  initSignAppDataReq()
+  initSignAppDataResp()
   initCachedAppData()
   initSendCachedAppDataReq()
 }

--- a/src/types/ajv/SignAppDataReq.ts
+++ b/src/types/ajv/SignAppDataReq.ts
@@ -1,19 +1,18 @@
 import { addSchema } from '../../utils/serialization/SchemaHelpers'
 import { AJVSchemaEnum } from '../enum/AJVSchemaEnum'
 
-export const schemaCachedAppData = {
+export const schemaSignAppDataReq = {
   type: 'object',
   properties: {
-    cycle: { type: 'number' },
-    appData: { type: 'object' },
-    dataID: { type: 'string' },
+    type: { type: 'string' },
+    nodesToSign: { type: 'number' },
+    hash: { type: 'string' },
+    appData: {}, // type unknown
   },
-  required: ['cycle', 'appData', 'dataID'],
-  additionalProperties: false,
-
+  required: ['type', 'nodesToSign', 'hash', 'appData'],
 }
 
-export function initCachedAppData(): void {
+export function initSignAppDataReq(): void {
   addSchemaDependencies()
   addSchemas()
 }
@@ -25,5 +24,5 @@ function addSchemaDependencies(): void {
 
 // Function to register the schema
 function addSchemas(): void {
-  addSchema(AJVSchemaEnum.CachedAppData, schemaCachedAppData)
+  addSchema(AJVSchemaEnum.SignAppDataReq, schemaSignAppDataReq)
 }

--- a/src/types/ajv/SignAppDataResp.ts
+++ b/src/types/ajv/SignAppDataResp.ts
@@ -1,0 +1,33 @@
+import { addSchema } from '../../utils/serialization/SchemaHelpers'
+import { AJVSchemaEnum } from '../enum/AJVSchemaEnum'
+
+export const schemaSignAppDataResp = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    signature: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string' },
+        sig: { type: 'string' },
+      },
+      required: ['owner', 'sig'],
+    },
+  },
+  required: ['success', 'signature'],
+}
+
+export function initSignAppDataResp(): void {
+  addSchemaDependencies()
+  addSchemas()
+}
+
+// Function to add schema dependencies
+function addSchemaDependencies(): void {
+  // No dependencies
+}
+
+// Function to register the schema
+function addSchemas(): void {
+  addSchema(AJVSchemaEnum.SignAppDataResp, schemaSignAppDataResp)
+}

--- a/src/types/enum/AJVSchemaEnum.ts
+++ b/src/types/enum/AJVSchemaEnum.ts
@@ -35,6 +35,8 @@ export enum AJVSchemaEnum {
   MakeReceiptReq = 'MakeReceiptReq',
   GetTrieHashesReq = 'GetTrieHashesReq',
   GetTrieHashesResp = 'GetTrieHashesResp',
+  SignAppDataReq = 'SignAppDataReq',
+  SignAppDataResp = 'SignAppDataResp',
   CachedAppData = 'CachedAppData',
   SendCachedAppDataReq = 'SendCachedAppDataReq',
   SpreadTxToGroupSyncingReq = 'SpreadTxToGroupSyncingReq',

--- a/test/unit/src/types/SignAppDataReq.test.ts
+++ b/test/unit/src/types/SignAppDataReq.test.ts
@@ -1,0 +1,115 @@
+import { VectorBufferStream } from '../../../../src/utils/serialization/VectorBufferStream'
+import {
+  cSignAppDataReqVersion,
+  deserializeSignAppDataReq,
+  serializeSignAppDataReq,
+  SignAppDataReq,
+} from '../../../../src/types/SignAppDataReq'
+import { TypeIdentifierEnum } from '../../../../src/types/enum/TypeIdentifierEnum'
+import { initSignAppDataReq } from '../../../../src/types/ajv/SignAppDataReq'
+import { Utils } from '@shardus/types'
+import { AppObjEnum } from '../../../../src/shardus/shardus-types'
+import { stateManager } from '../../../../src/p2p/Context'
+
+// Mock the Context module and its nested structure
+jest.mock('../../../../src/p2p/Context', () => ({
+  setDefaultConfigs: jest.fn(),
+  stateManager: {
+    app: {
+      binarySerializeObject: jest.fn((enumType, data) => Buffer.from(Utils.safeStringify(data), 'utf8')),
+      binaryDeserializeObject: jest.fn((enumType, buffer) => Utils.safeJsonParse(buffer.toString('utf8'))),
+    },
+  },
+}))
+
+describe('SignAppDataReq Tests', () => {
+  beforeAll(() => {
+    initSignAppDataReq()
+  })
+
+  describe('Serialization Tests', () => {
+    test('Serialize valid data with root true', () => {
+      const obj: SignAppDataReq = {
+        type: 'type1',
+        nodesToSign: 2,
+        hash: 'hash123',
+        appData: 'appData123',
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataReq(stream, obj, true)
+      const expectedStream = new VectorBufferStream(0)
+      expectedStream.writeUInt16(TypeIdentifierEnum.cSignAppDataReq)
+      expectedStream.writeUInt8(cSignAppDataReqVersion)
+      expectedStream.writeString('type1')
+      expectedStream.writeUInt8(2)
+      expectedStream.writeString('hash123')
+      expectedStream.writeBuffer(stateManager.app.binarySerializeObject(AppObjEnum.AppData, 'appData123'))
+
+      expect(stream.getBuffer()).toEqual(expectedStream.getBuffer())
+    })
+
+    test('Serialize empty array with root false', () => {
+      const obj: SignAppDataReq = {
+        type: 'type1',
+        nodesToSign: 3,
+        hash: 'hash123',
+        appData: 'appData123',
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataReq(stream, obj, false)
+      const expectedStream = new VectorBufferStream(0)
+      expectedStream.writeUInt8(cSignAppDataReqVersion)
+      expectedStream.writeString('type1')
+      expectedStream.writeUInt8(3)
+      expectedStream.writeString('hash123')
+      expectedStream.writeBuffer(stateManager.app.binarySerializeObject(AppObjEnum.AppData, 'appData123'))
+
+      expect(stream.getBuffer()).toEqual(expectedStream.getBuffer())
+    })
+  })
+
+  describe('Deserialization Tests', () => {
+    test('Deserialize valid data', () => {
+      const stream = new VectorBufferStream(0)
+      stream.writeUInt8(cSignAppDataReqVersion)
+      stream.writeString('type1')
+      stream.writeUInt8(2)
+      stream.writeString('hash123')
+      stream.writeBuffer(stateManager.app.binarySerializeObject(AppObjEnum.AppData, 'appData123'))
+      stream.position = 0
+
+      const result = deserializeSignAppDataReq(stream)
+      expect(result).toEqual({
+        type: 'type1',
+        nodesToSign: 2,
+        hash: 'hash123',
+        appData: 'appData123',
+      })
+    })
+
+    test('Version mismatch error', () => {
+      const stream = new VectorBufferStream(0)
+      stream.writeUInt8(cSignAppDataReqVersion + 1)
+      stream.position = 0
+
+      expect(() => deserializeSignAppDataReq(stream)).toThrow('SignAppDataReq version mismatch')
+    })
+  })
+
+  describe('SignAppDataReq Serialization and Deserialization Together', () => {
+    test('Correct round-trip for non-empty array', () => {
+      const originalObj: SignAppDataReq = {
+        type: 'type1',
+        nodesToSign: 3,
+        hash: 'hash123',
+        appData: 'appData123',
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataReq(stream, originalObj, false)
+      stream.position = 0
+
+      const deserializedObj = deserializeSignAppDataReq(stream)
+      expect(deserializedObj).toEqual(originalObj)
+    })
+  })
+})

--- a/test/unit/src/types/SignAppDataResp.test.ts
+++ b/test/unit/src/types/SignAppDataResp.test.ts
@@ -1,0 +1,101 @@
+import { VectorBufferStream } from '../../../../src/utils/serialization/VectorBufferStream'
+import {
+  cSignAppDataRespVersion,
+  deserializeSignAppDataResp,
+  serializeSignAppDataResp,
+  SignAppDataResp,
+} from '../../../../src/types/SignAppDataResp'
+import { TypeIdentifierEnum } from '../../../../src/types/enum/TypeIdentifierEnum'
+import { initSignAppDataResp } from '../../../../src/types/ajv/SignAppDataResp'
+
+describe('SignAppDataResp Tests', () => {
+  beforeAll(() => {
+    initSignAppDataResp()
+  })
+
+  describe('Serialization Tests', () => {
+    test('Serialize valid data with root true', () => {
+      const obj: SignAppDataResp = {
+        success: true,
+        signature: {
+          owner: 'owner123',
+          sig: 'sig123',
+        },
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataResp(stream, obj, true)
+      const expectedStream = new VectorBufferStream(0)
+      expectedStream.writeUInt16(TypeIdentifierEnum.cSignAppDataResp)
+      expectedStream.writeUInt8(cSignAppDataRespVersion)
+      expectedStream.writeUInt8(1)
+      expectedStream.writeString('owner123')
+      expectedStream.writeString('sig123')
+
+      expect(stream.getBuffer()).toEqual(expectedStream.getBuffer())
+    })
+
+    test('Serialize empty array with root false', () => {
+      const obj: SignAppDataResp = {
+        success: true,
+        signature: {
+          owner: 'owner123',
+          sig: 'sig123',
+        },
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataResp(stream, obj, false)
+      const expectedStream = new VectorBufferStream(0)
+      expectedStream.writeUInt8(cSignAppDataRespVersion)
+      expectedStream.writeUInt8(1)
+      expectedStream.writeString('owner123')
+      expectedStream.writeString('sig123')
+      expect(stream.getBuffer()).toEqual(expectedStream.getBuffer())
+    })
+  })
+
+  describe('Deserialization Tests', () => {
+    test('Deserialize valid data', () => {
+      const stream = new VectorBufferStream(0)
+      stream.writeUInt8(cSignAppDataRespVersion)
+      stream.writeUInt8(1)
+      stream.writeString('owner123')
+      stream.writeString('sig123')
+      stream.position = 0
+
+      const result = deserializeSignAppDataResp(stream)
+      expect(result).toEqual({
+        success: true,
+        signature: {
+          owner: 'owner123',
+          sig: 'sig123',
+        },
+      })
+    })
+
+    test('Version mismatch error', () => {
+      const stream = new VectorBufferStream(0)
+      stream.writeUInt8(cSignAppDataRespVersion + 1)
+      stream.position = 0
+
+      expect(() => deserializeSignAppDataResp(stream)).toThrow('SignAppDataResp version mismatch')
+    })
+  })
+
+  describe('SignAppDataResp Serialization and Deserialization Together', () => {
+    test('Correct round-trip for non-empty array', () => {
+      const originalObj: SignAppDataResp = {
+        success: true,
+        signature: {
+          owner: 'owner123',
+          sig: 'sig123',
+        },
+      }
+      const stream = new VectorBufferStream(0)
+      serializeSignAppDataResp(stream, originalObj, false)
+      stream.position = 0
+
+      const deserializedObj = deserializeSignAppDataResp(stream)
+      expect(deserializedObj).toEqual(originalObj)
+    })
+  })
+})


### PR DESCRIPTION
https://linear.app/shm/issue/RED-140/debug-endpoint-crashes-on-windows

Summary: add path normalization by converting `\` to `/` for consistent handling across OS. Added error handling to prevent crashes for no valid trie entry or destination found. Along with debugging logging behind a flag.