### PR TITLE
RED-127 gossip join requests without double queueing

### DIFF
--- a/src/p2p/Join/v2/index.ts
+++ b/src/p2p/Join/v2/index.ts
@@ -249,6 +249,8 @@ export function isOnStandbyList(publicKey: string): boolean {
 }
 
 export function isInNewJoinRequests(publicKey: string): boolean {
+  return newJoinRequests.some((node) => node.nodeInfo.publicKey === publicKey);
+}
   if (newJoinRequests.find((node) => node.nodeInfo.publicKey === publicKey)) {
     return true
   } else {

--- a/src/p2p/Join/v2/index.ts
+++ b/src/p2p/Join/v2/index.ts
@@ -251,12 +251,6 @@ export function isOnStandbyList(publicKey: string): boolean {
 export function isInNewJoinRequests(publicKey: string): boolean {
   return newJoinRequests.some((node) => node.nodeInfo.publicKey === publicKey);
 }
-  if (newJoinRequests.find((node) => node.nodeInfo.publicKey === publicKey)) {
-    return true
-  } else {
-    return false
-  }
-}
 
 export function debugDumpJoinRequestList(list: JoinRequest[], message: string): void {
   list.sort((a, b) => (a.nodeInfo.publicKey > b.nodeInfo.publicKey ? 1 : -1))

--- a/src/p2p/Join/v2/index.ts
+++ b/src/p2p/Join/v2/index.ts
@@ -248,6 +248,14 @@ export function isOnStandbyList(publicKey: string): boolean {
   }
 }
 
+export function isInNewJoinRequests(publicKey: string): boolean {
+  if (newJoinRequests.find((node) => node.nodeInfo.publicKey === publicKey)) {
+    return true
+  } else {
+    return false
+  }
+}
+
 export function debugDumpJoinRequestList(list: JoinRequest[], message: string): void {
   list.sort((a, b) => (a.nodeInfo.publicKey > b.nodeInfo.publicKey ? 1 : -1))
   //let getSortedStandbyNodeList = JoinV2.getSortedStandbyJoinRequests()


### PR DESCRIPTION
whenever we received a join request, we used to always save it to be gossiped next cycle, even if we received it before sendRequests(the time to send a joinRequest) was called. This was achieved with a double queue. This forced waiting caused network spin-up to take longer. We have gotten rid of it now in favor of a single queue and handled the issues that come with that approach.