### PR TITLE
GOLD-164: Signature majority validation for non locally produced receipts

### DIFF
--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -1484,14 +1484,14 @@ class TransactionConsenus {
   }
 
   verifyAppliedReceipt(receipt: AppliedReceipt2, executionGroupNodes: Set<string>): boolean {
-    const ownerToSignMap = new Map();
+    const ownerToSignMap = new Map<string, Shardus.Sign>();
     for (const sign of receipt.signatures) {
       if (executionGroupNodes.has(sign.owner)) {
         ownerToSignMap.set(sign.owner, sign);
       }
     }
     const totalNodes = executionGroupNodes.size;
-    const requiredMajority = Math.round(totalNodes * (2 / 3.0)); //hacky for now.
+    const requiredMajority = Math.ceil(totalNodes * this.config.p2p.requiredVotesPercentage)
     if (ownerToSignMap.size < requiredMajority) {
       return false;
     }

--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -1098,16 +1098,9 @@ class TransactionConsenus {
             return
           }
 
-          // Continue if we've already processed this before
-          if (queueEntry.hasSentFinalReceipt) {
-            return
-          }
-
-          const executionGroupNodes = new Set(queueEntry.executionGroup.map(node => node.publicKey));
-          const hasTwoThirdsMajority = this.verifyAppliedReceipt(readableReq.receipt, executionGroupNodes)
-          if(!hasTwoThirdsMajority) {
-            /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Receipt does not have the required majority for txid: ${readableReq.receipt.txid}`)
-            nestedCountersInstance.countEvent('poqo', 'poqo-data-and-receipt: Rejecting receipt because no majority')
+          // validate corresponding tell sender
+          if (_sender == null) {
+            /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`poqo-data-and-receipt invalid sender for txid: ${readableReq.finalState.txid}, sender: ${_sender}`)
             return
           }
 
@@ -1126,11 +1119,7 @@ class TransactionConsenus {
               /* prettier-ignore */ if (logFlags.error && logFlags.verbose) this.mainLogger.error(`poqo-data-and-receipt data == null`)
               continue
             }
-            // validate corresponding tell sender
-            if (_sender == null) {
-              /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`poqo-data-and-receipt invalid sender for data: ${data.accountId}, sender: ${_sender}`)
-              continue
-            }
+            
             const isValidFinalDataSender =
               this.stateManager.transactionQueue.factValidateCorrespondingTellFinalDataSender(
                 queueEntry,
@@ -1179,6 +1168,13 @@ class TransactionConsenus {
             nestedCountersInstance.countEvent(`processing`, `forwarded final data to storage nodes`)
           }
           if (!queueEntry.hasSentFinalReceipt) {
+            const executionGroupNodes = new Set(queueEntry.executionGroup.map(node => node.publicKey));
+            const hasTwoThirdsMajority = this.verifyAppliedReceipt(readableReq.receipt, executionGroupNodes)
+            if(!hasTwoThirdsMajority) {
+              /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Receipt does not have the required majority for txid: ${readableReq.receipt.txid}`)
+              nestedCountersInstance.countEvent('poqo', 'poqo-data-and-receipt: Rejecting receipt because no majority')
+              return
+            }
             if (logFlags.verbose)
               this.mainLogger.debug(
                 `POQo: received data & receipt for ${queueEntry.logID} starting receipt gossip`
@@ -1236,16 +1232,9 @@ class TransactionConsenus {
             return
           }
 
-          // Continue if we've already processed this before
-          if (queueEntry.hasSentFinalReceipt) {
-            return
-          }
-
-          const executionGroupNodes = new Set(queueEntry.executionGroup.map(node => node.publicKey));
-          const hasTwoThirdsMajority = this.verifyAppliedReceipt(payload.receipt, executionGroupNodes)
-          if(!hasTwoThirdsMajority) {
-            /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Receipt does not have the required majority for txid: ${payload.receipt.txid}`)
-            nestedCountersInstance.countEvent('poqo', 'poqo-data-and-receipt: Rejecting receipt because no majority')
+          // validate corresponding tell sender
+          if (_sender == null) {
+            /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`poqo-data-and-receipt invalid sender for txid: ${payload.finalState.txid}, sender: ${_sender}`)
             return
           }
 
@@ -1260,11 +1249,7 @@ class TransactionConsenus {
               /* prettier-ignore */ if (logFlags.error && logFlags.verbose) this.mainLogger.error(`poqo-data-and-receipt data == null`)
               continue
             }
-            // validate corresponding tell sender
-            if (_sender == null) {
-              /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`poqo-data-and-receipt invalid sender for data: ${data.accountId}, sender: ${_sender}`)
-              continue
-            }
+
             const isValidFinalDataSender = this.stateManager.transactionQueue.factValidateCorrespondingTellFinalDataSender(queueEntry, data.accountId, _sender)
             if (isValidFinalDataSender === false) {
               /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`poqo-data-and-receipt invalid sender ${_sender} for data: ${data.accountId}`)
@@ -1307,6 +1292,13 @@ class TransactionConsenus {
             nestedCountersInstance.countEvent(`processing`, `forwarded final data to storage nodes`)
           }
           if (!queueEntry.hasSentFinalReceipt) {
+            const executionGroupNodes = new Set(queueEntry.executionGroup.map(node => node.publicKey));
+            const hasTwoThirdsMajority = this.verifyAppliedReceipt(payload.receipt, executionGroupNodes)
+            if(!hasTwoThirdsMajority) {
+              /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Receipt does not have the required majority for txid: ${payload.receipt.txid}`)
+              nestedCountersInstance.countEvent('poqo', 'poqo-data-and-receipt: Rejecting receipt because no majority')
+              return
+            }
             if (logFlags.verbose) this.mainLogger.debug(`POQo: received data & receipt for ${queueEntry.logID} starting receipt gossip`)
             queueEntry.poqoReceipt = payload.receipt
             queueEntry.appliedReceipt2 = payload.receipt


### PR DESCRIPTION
A new method **verifyTwoThirdsMajority** has been added to the **TransactionConsensus** class, which takes receipt and executionGroupNodes as input parameters. This method verifies if the receipt has more than 2/3rd of the valid signers by calculating the required majority.