### PR TITLE
RED-247: Add null check for `queueEntry` when getting index value in the TransactionQueue processing loop

### DIFF
--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -5609,7 +5609,12 @@ class TransactionQueue {
         this.clearDebugAwaitStrings()
 
         // eslint-disable-next-line security/detect-object-injection
-        const queueEntry: QueueEntry = this._transactionQueue[currentIndex]
+        const queueEntry: QueueEntry | undefined = this._transactionQueue[currentIndex]
+        if (!queueEntry) {
+          this.statemanager_fatal(`queueEntry is null`, `currentIndex:${currentIndex}`)
+          nestedCountersInstance.countEvent('processing', 'error: null queue entry. skipping to next TX')
+          continue
+        }
         if (logFlags.seqdiagram)  this.mainLogger.info(`0x10052024 ${ipInfo.externalIp} ${shardusGetTime()} 0x0001 currentIndex:${currentIndex} txId:${queueEntry.acceptedTx.txId} state:${queueEntry.state}`)
         const txTime = queueEntry.txKeys.timestamp
         const txAge = currentTime - txTime

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -5610,7 +5610,7 @@ class TransactionQueue {
 
         // eslint-disable-next-line security/detect-object-injection
         const queueEntry: QueueEntry | undefined = this._transactionQueue[currentIndex]
-        if (!queueEntry) {
+        if (queueEntry == null) {
           this.statemanager_fatal(`queueEntry is null`, `currentIndex:${currentIndex}`)
           nestedCountersInstance.countEvent('processing', 'error: null queue entry. skipping to next TX')
           continue


### PR DESCRIPTION
https://shardeum.slack.com/archives/C07F5L9TF33/p1723222226341989?thread_ts=1723210967.343049&cid=C07F5L9TF33
Above is the ask

Summary: Add null check for queue entry in TransactionQueue processing loop

- Prevent potential null error causing node to error out
- Log error and skip to next transaction if queue entry is null