### PR TITLE
GOLD 200 : Use network generated timestamps (ignore nonce queue) for non-config internal txs

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -143,7 +143,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     extraNodesToAddInRestart: 5,
     secondsToCheckForQ1: 1000, // 1 seconds in ms
     hardenNewSyncingProtocol: true,
-    removeLostSyncingNodeFromList: true,  //set to true since 1.10
+    removeLostSyncingNodeFromList: true, //set to true since 1.10
     compareCertBinary: true,
     makeReceiptBinary: true,
     lostArchiverInvestigateBinary: true,
@@ -172,7 +172,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     requestReceiptForTxBinary: true,
     lostReportBinary: true,
     repairMissingAccountsBinary: true,
-    poqoSendReceiptBinary : true,
+    poqoSendReceiptBinary: true,
     poqoDataAndReceiptBinary: true,
     poqoSendVoteBinary: true,
     rotationEdgeToAvoid: 3,
@@ -184,7 +184,8 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     useFactCorrespondingTell: true,
     resubmitStandbyAddWaitDuration: 1000, // 1 second in ms
     requiredVotesPercentage: 2 / 3.0,
-    timestampCacheFix: true
+    timestampCacheFix: true,
+    networkGeneratedTimestampFixes: true,
   },
   ip: {
     externalIp: '0.0.0.0',
@@ -318,7 +319,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     voterPercentage: 0.1,
     waitUpstreamTx: false,
     gossipCompleteData: false,
-    shareCompleteData: false,  //turn off the neighbor sharing of complete data.
+    shareCompleteData: false, //turn off the neighbor sharing of complete data.
     txStateMachineChanges: true,
     canRequestFinalData: true,
     numberOfReInjectNodes: 5,
@@ -340,7 +341,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     stuckTxMoveTime: 60000,
     forceVoteForFailedPreApply: true,
     collectedDataFix: true,
-    noRepairIfDataAttached: false,  // this seems to be an optimization that we will leave off for now
+    noRepairIfDataAttached: false, // this seems to be an optimization that we will leave off for now
     rejectSharedDataIfCovered: false,
     requestAwaitedDataAllowed: false, // this has been disabled by accident for a long time so leaving it off
     awaitingDataCanBailOnReceipt: true,

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -1474,6 +1474,10 @@ class Shardus extends EventEmitter {
           status: 500,
         }
       }
+      if(this.app.isInternalTx(tx)){
+        let result = await this._timestampAndQueueTransaction(tx, appData, global, noConsensus)
+        return result
+      }
       if (shouldAddToNonceQueue) {
         const nonceQueueEntry: NonceQueueItem = {
           tx,

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -1474,7 +1474,7 @@ class Shardus extends EventEmitter {
           status: 500,
         }
       }
-      if(this.app.isInternalTx(tx)){
+      if (this.app.isInternalTx(tx) && this.config.p2p.networkGeneratedTimestampFixes) {
         let result = await this._timestampAndQueueTransaction(tx, appData, global, noConsensus)
         return result
       }

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -963,6 +963,8 @@ export interface ServerConfiguration {
     requiredVotesPercentage: number
     // /** a fix to prevent node from producing different ts for same txId */
     timestampCacheFix: boolean
+    // to allow internal transactions to have network generated timestamps
+    networkGeneratedTimestampFixes: boolean
   }
   /** Server IP configuration */
   ip?: {


### PR DESCRIPTION
Linear : https://linear.app/shm/issue/GOLD-200/use-network-generated-timestamps-ignore-nonce-queue-for-non-config