### PR TITLE
SYS-332, SYS-375, SYS-376, SYS-377, SYS-378: Add `validateJoinRequest.test.ts`

### DIFF
--- a/src/p2p/Join/logging.ts
+++ b/src/p2p/Join/logging.ts
@@ -1,0 +1,26 @@
+import { Logger } from 'log4js'
+import { logger } from '../Context'
+
+export function initLogging(): void {
+  p2pLogger = logger.getLogger('p2p')
+}
+
+let p2pLogger: Logger
+export function getP2PLogger(): Logger {
+  return p2pLogger
+}
+
+export function info(...msg: string[]): void {
+  const entry = `Join: ${msg.join(' ')}`
+  getP2PLogger().info(entry)
+}
+
+export function warn(...msg: string[]): void {
+  const entry = `Join: ${msg.join(' ')}`
+  getP2PLogger().warn(entry)
+}
+
+export function error(...msg: string[]): void {
+  const entry = `Join: ${msg.join(' ')}`
+  getP2PLogger().error(entry)
+}

--- a/src/p2p/Join/state.ts
+++ b/src/p2p/Join/state.ts
@@ -1,0 +1,17 @@
+import { P2P } from '@shardus/types'
+
+let seen: Set<P2P.P2PTypes.Node['publicKey']>
+export function getSeen(): Set<string> {
+  return seen
+}
+export function resetSeen(): void {
+  seen = new Set()
+}
+
+let allowBogon = false
+export function setAllowBogon(value: boolean): void {
+  allowBogon = value
+}
+export function getAllowBogon(): boolean {
+  return allowBogon
+}

--- a/src/p2p/Join/types.ts
+++ b/src/p2p/Join/types.ts
@@ -1,0 +1,10 @@
+export interface JoinRequestResponse {
+  /** Whether the join request was accepted. TODO: consider renaming to `accepted`? */
+  success: boolean
+
+  /** A message explaining the result of the join request. */
+  reason: string
+
+  /** Whether the join request could not be accepted due to some error, usually in validating a join request. TODO: consider renaming to `invalid`? */
+  fatal: boolean
+}

--- a/src/p2p/Join/validate.ts
+++ b/src/p2p/Join/validate.ts
@@ -27,7 +27,8 @@ export function validateJoinRequest(joinRequest: P2P.JoinTypes.JoinRequest): Joi
     validateJoinRequestHost(joinRequest.nodeInfo.externalIp) ||
     verifyUnseen(joinRequest.nodeInfo.publicKey) ||
     verifyNodeUnknown(joinRequest.nodeInfo) ||
-    validateJoinRequestTimestamp(joinRequest.nodeInfo.joinRequestTimestamp)
+    validateJoinRequestTimestamp(joinRequest.nodeInfo.joinRequestTimestamp) ||
+    null
   )
 }
 

--- a/src/p2p/Join/validate.ts
+++ b/src/p2p/Join/validate.ts
@@ -251,7 +251,7 @@ export const ALREADY_SEEN_ERROR = {
  * If the `joinRequest`'s node has not already been seen this cycle, it returns
  * `null`.
  */
-function verifyUnseen(publicKey: hexstring): JoinRequestResponse | null {
+export function verifyUnseen(publicKey: hexstring): JoinRequestResponse | null {
   // Check if this node has already been seen this cycle
   if (getSeen().has(publicKey)) {
     if (logFlags.p2pNonFatal) nestedCountersInstance.countEvent('p2p', `join-skip-seen-pubkey`)

--- a/src/p2p/Join/validate.ts
+++ b/src/p2p/Join/validate.ts
@@ -1,0 +1,296 @@
+import { version } from '../../../package.json'
+import { logFlags } from '../../logger'
+import { hexstring, P2P } from '@shardus/types'
+import * as utils from '../../utils'
+import { isEqualOrNewerVersion } from '../../utils'
+import { config } from '../Context'
+import * as CycleChain from '../CycleChain'
+import * as NodeList from '../NodeList'
+import { isBogonIP, isInvalidIP, isIPv6 } from '../../utils/functions/checkIP'
+import { nestedCountersInstance } from '../../utils/nestedCounters'
+import { Utils } from '@shardus/types'
+import { JoinRequestResponse } from './types'
+import { info, warn } from './logging'
+import { getAllowBogon, getSeen } from './state'
+
+/**
+ * Returns a `JoinRequestResponse` object if the given `joinRequest` is invalid or rejected for any reason.
+ */
+export function validateJoinRequest(joinRequest: P2P.JoinTypes.JoinRequest): JoinRequestResponse | null {
+  // perform validation. if any of these functions return a non-null value,
+  // validation fails and the join request is rejected
+  return (
+    verifyJoinRequestTypes(joinRequest) ||
+    validateVersion(joinRequest.version) ||
+    verifyJoinRequestSigner(joinRequest) ||
+    verifyNotIPv6(joinRequest.nodeInfo.externalIp) ||
+    validateJoinRequestHost(joinRequest.nodeInfo.externalIp) ||
+    verifyUnseen(joinRequest.nodeInfo.publicKey) ||
+    verifyNodeUnknown(joinRequest.nodeInfo) ||
+    validateJoinRequestTimestamp(joinRequest.nodeInfo.joinRequestTimestamp)
+  )
+}
+
+export const BOGON_NOT_ACCEPTED_ERROR = {
+  success: false,
+  reason: `Bad ip, bogon ip not accepted`,
+  fatal: true,
+}
+export const RESERVED_IP_REJECTED_ERROR = {
+  success: false,
+  reason: `Bad ip, reserved ip not accepted`,
+  fatal: true,
+}
+/**
+ * Returns an error response if the given `externalIp` is invalid or rejected.
+ */
+export function validateJoinRequestHost(externalIp: string): JoinRequestResponse | null {
+  try {
+    //test or bogon IPs and reject the join request if they appear
+    if (!getAllowBogon()) {
+      if (isBogonIP(externalIp)) {
+        /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('Got join request from Bogon IP')
+        nestedCountersInstance.countEvent('p2p', `join-reject-bogon`)
+        return BOGON_NOT_ACCEPTED_ERROR
+      }
+    } else {
+      //even if not checking bogon still reject other invalid IPs that would be unusable
+      if (isInvalidIP(externalIp)) {
+        /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('Got join request from invalid reserved IP')
+        nestedCountersInstance.countEvent('p2p', `join-reject-reserved`)
+        return RESERVED_IP_REJECTED_ERROR
+      }
+    }
+  } catch (er) {
+    nestedCountersInstance.countEvent('p2p', `join-reject-bogon-ex:${er}`)
+    return {
+      success: false,
+      reason: `Error in checking IP: ${er}`,
+      fatal: true,
+    }
+  }
+
+  return null
+}
+
+/**
+ * This function is a little weird because it was taken directly from
+ * `addJoinRequest`, but here's how it works:
+ *
+ * It validates the types of the `joinRequest`. If the types are invalid, it
+ * returns a `JoinRequestResponse` object with `success` set to `false` and
+ * `fatal` set to `true`. The `reason` field will contain a message describing
+ * the validation error.
+ *
+ * If the types are valid, it returns `null`.
+ */
+export function verifyJoinRequestTypes(joinRequest: P2P.JoinTypes.JoinRequest): JoinRequestResponse | null {
+  // Validate joinReq
+  let err = utils.validateTypes(joinRequest, {
+    cycleMarker: 's',
+    nodeInfo: 'o',
+    sign: 'o',
+    version: 's',
+  })
+  if (err) {
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('join bad joinRequest ' + err)
+    return {
+      success: false,
+      reason: `Bad join request object structure`,
+      fatal: true,
+    }
+  }
+  err = utils.validateTypes(joinRequest.nodeInfo, {
+    activeTimestamp: 'n',
+    address: 's',
+    externalIp: 's',
+    externalPort: 'n',
+    internalIp: 's',
+    internalPort: 'n',
+    joinRequestTimestamp: 'n',
+    publicKey: 's',
+  })
+  if (err) {
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('join bad joinRequest.nodeInfo ' + err)
+    return {
+      success: false,
+      reason: 'Bad nodeInfo object structure within join request',
+      fatal: true,
+    }
+  }
+  err = utils.validateTypes(joinRequest.sign, { owner: 's', sig: 's' })
+  if (err) {
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('join bad joinRequest.sign ' + err)
+    return {
+      success: false,
+      reason: 'Bad signature object structure within join request',
+      fatal: true,
+    }
+  }
+
+  return null
+}
+
+/**
+ * Makes sure that the given `nodeInfo` is not already known to the network.
+ * If it is, it returns a `JoinRequestResponse` object with `success` set to
+ * `false` and `fatal` set to `true`. The `reason` field will contain a message
+ * describing the validation error.
+ *
+ * If the `nodeInfo` is not already known to the network, it returns `null`.
+ */
+function verifyNodeUnknown(nodeInfo: P2P.P2PTypes.P2PNode): JoinRequestResponse | null {
+  if (NodeList.byPubKey.has(nodeInfo.publicKey)) {
+    const message = 'Cannot add join request for this node, already a known node (by public key).'
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn(message)
+    return {
+      success: false,
+      reason: message,
+      fatal: false,
+    }
+  }
+  const ipPort = NodeList.ipPort(nodeInfo.internalIp, nodeInfo.internalPort)
+  if (NodeList.byIpPort.has(ipPort)) {
+    const message = 'Cannot add join request for this node, already a known node (by IP address).'
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) info(message, Utils.safeStringify(NodeList.byIpPort.get(ipPort)))
+    if (logFlags.p2pNonFatal) nestedCountersInstance.countEvent('p2p', `join-skip-already-known`)
+    return {
+      success: false,
+      reason: message,
+      fatal: true,
+    }
+  }
+
+  return null
+}
+
+/**
+ * Makes sure that the given `externalIp` is not an IPv6 address. If it
+ * is, it returns a `JoinRequestResponse` object with `success` set to `false`
+ * and `fatal` set to `true`. The `reason` field will contain a message
+ * describing the validation error.
+ *
+ * If the `externalIp` is not an IPv6 address, it returns `null`.
+ */
+export function verifyNotIPv6(externalIp: string): JoinRequestResponse | null {
+  if (isIPv6(externalIp)) {
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('Got join request from IPv6')
+    nestedCountersInstance.countEvent('p2p', `join-reject-ipv6`)
+    return {
+      success: false,
+      reason: `Bad ip version, IPv6 are not accepted`,
+      fatal: true,
+    }
+  }
+  return null
+}
+
+/**
+ * Makes sure that the given `joinRequestVersion` is not older than the
+ * current version of the node. If it is, it returns a `JoinRequestResponse`
+ * object with `success` set to `false` and `fatal` set to `true`. The `reason`
+ * field will contain a message describing the validation error.
+ *
+ * If the `joinRequestVersion` is not older than the current version of the
+ * node, it returns `null`.
+ */
+export function validateVersion(joinRequestVersion: string): JoinRequestResponse | null {
+  if (config.p2p.checkVersion && !isEqualOrNewerVersion(version, joinRequestVersion)) {
+    /* prettier-ignore */ warn(`version number is old. Our node version is ${version}. Join request node version is ${joinRequestVersion}`)
+    nestedCountersInstance.countEvent('p2p', `join-reject-version ${joinRequestVersion}`)
+    return {
+      success: false,
+      reason: `Old shardus core version, please statisfy at least ${version}`,
+      fatal: true,
+    }
+  } else return null
+}
+
+/**
+ * Makes sure that the given `joinRequest` is signed by the node that is
+ * attempting to join. If it is not, it returns a `JoinRequestResponse` object
+ * with `success` set to `false` and `fatal` set to `true`. The `reason` field
+ * will contain a message describing the validation error.
+ *
+ * If the `joinRequest` is signed by the node that is attempting to join, it
+ * returns `null`.
+ */
+export function verifyJoinRequestSigner(joinRequest: P2P.JoinTypes.JoinRequest): JoinRequestResponse | null {
+  //If the node that signed the request is not the same as the node that is joining
+  if (joinRequest.sign.owner != joinRequest.nodeInfo.publicKey) {
+    /* prettier-ignore */ warn(`join-reject owner != publicKey ${{ sign: joinRequest.sign.owner, info: joinRequest.nodeInfo.publicKey }}`)
+    nestedCountersInstance.countEvent('p2p', `join-reject owner != publicKey`)
+    return {
+      success: false,
+      reason: `Bad signature, sign owner and node attempted joining mismatched`,
+      fatal: true,
+    }
+  }
+
+  return null
+}
+
+/**
+ * Makes sure that the given `joinRequest`'s node  has not already been seen this
+ * cycle. If it has, it returns a `JoinRequestResponse` object with `success`
+ * set to `false` and `fatal` set to `false`. The `reason` field will contain a
+ * message describing the validation error.
+ *
+ * If the `joinRequest`'s node has not already been seen this cycle, it returns
+ * `null`.
+ */
+function verifyUnseen(publicKey: hexstring): JoinRequestResponse | null {
+  // Check if this node has already been seen this cycle
+  if (getSeen().has(publicKey)) {
+    if (logFlags.p2pNonFatal) nestedCountersInstance.countEvent('p2p', `join-skip-seen-pubkey`)
+    if (logFlags.p2pNonFatal) info('Node has already been seen this cycle. Unable to add join request.')
+    return {
+      success: false,
+      reason: 'Node has already been seen this cycle. Unable to add join request.',
+      fatal: false,
+    }
+  }
+
+  // Mark node as seen for this cycle
+  getSeen().add(publicKey)
+
+  return null
+}
+
+function validateJoinRequestTimestamp(joinRequestTimestamp: number): JoinRequestResponse | null {
+  //TODO - figure out why joinRequest is send with previous cycle marker instead of current cycle marker
+  /*
+   CONTEXT: when node create join request the cycleMarker is (current - 1).
+   The reason join request didn't use current cycleMarker is most likely the the current cycle is potential not agreed upon yet.
+   but the joinRequestTimestamp is Date.now
+   so checking if the timestamp is within its cycleMarker is gurantee to fail
+   let request cycle marker be X, then X+1 is current cycle, then we check if the timestamp is in the current cycleMarker
+  */
+  // const cycleThisJoinRequestBelong = CycleChain.cyclesByMarker[joinRequest.cycleMarker]
+  // const cycleStartedAt = cycleThisJoinRequestBelong.start
+  // const cycleWillEndsAt = cycleStartedAt + cycleDuration
+  const cycleDuration = CycleChain.newest.duration
+  const cycleStarts = CycleChain.newest.start
+  const requestValidUpperBound = cycleStarts + cycleDuration
+  const requestValidLowerBound = cycleStarts - cycleDuration
+
+  if (joinRequestTimestamp < requestValidLowerBound) {
+    nestedCountersInstance.countEvent('p2p', `join-skip-timestamp-not-meet-lowerbound`)
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('Cannot add join request for this node, timestamp is earlier than allowed cycle range')
+    return {
+      success: false,
+      reason: 'Cannot add join request, timestamp is earlier than allowed cycle range',
+      fatal: false,
+    }
+  }
+
+  if (joinRequestTimestamp > requestValidUpperBound) {
+    nestedCountersInstance.countEvent('p2p', `join-skip-timestamp-beyond-upperbound`)
+    /* prettier-ignore */ if (logFlags.p2pNonFatal) warn('Cannot add join request for this node, its timestamp exceeds allowed cycle range')
+    return {
+      success: false,
+      reason: 'Cannot add join request, timestamp exceeds allowed cycle range',
+      fatal: false,
+    }
+  }
+}

--- a/src/p2p/Join/validate.ts
+++ b/src/p2p/Join/validate.ts
@@ -200,7 +200,7 @@ export function validateVersion(joinRequestVersion: string): JoinRequestResponse
     nestedCountersInstance.countEvent('p2p', `join-reject-version ${joinRequestVersion}`)
     return {
       success: false,
-      reason: `Old shardus core version, please statisfy at least ${version}`,
+      reason: `Old shardus core version, please satisfy at least ${version}`,
       fatal: true,
     }
   } else return null

--- a/src/p2p/NodeList.ts
+++ b/src/p2p/NodeList.ts
@@ -515,6 +515,14 @@ export function changeNodeListInRestore(cycleStartTimestamp: number) {
   }
 }
 
+export function getByPubKeyMap() {
+  return byPubKey
+}
+
+export function getByIpPortMap() {
+  return byIpPort
+}
+
 /** ROUTES */
 
 function info(...msg: string[]) {

--- a/test/unit/src/validateJoinRequest.test.ts
+++ b/test/unit/src/validateJoinRequest.test.ts
@@ -1,0 +1,405 @@
+import { version as packageVersion } from '../../../package.json'
+import { JoinRequest } from '@shardus/types/build/src/p2p/JoinTypes'
+import {
+  ALREADY_KNOWN_IP_ERROR,
+  ALREADY_KNOWN_PK_ERROR,
+  ALREADY_SEEN_ERROR,
+  BAD_SIGNATURE_ERROR,
+  BAD_STRUCTURE_ERROR,
+  BAD_VERSION_ERROR,
+  BOGON_NOT_ACCEPTED_ERROR,
+  EARLY_TIMESTAMP_ERROR,
+  IPV6_ERROR,
+  LATE_TIMESTAMP_ERROR,
+  RESERVED_IP_REJECTED_ERROR,
+  validateJoinRequest,
+  validateJoinRequestHost,
+  validateVersion,
+  verifyJoinRequestSigner,
+  verifyJoinRequestTypes,
+  verifyNotIPv6,
+} from '../../../src/p2p/Join/validate'
+import { JoinRequestResponse } from '../../../src/p2p/Join/types'
+import { getAllowBogon, getSeen } from '../../../src/p2p/Join/state'
+import { getByIpPortMap, getByPubKeyMap } from '../../../src/p2p/NodeList'
+
+jest.mock('../../../src/p2p/Context', () => ({
+  setDefaultConfigs: jest.fn(),
+  config: {
+    p2p: {
+      checkVersion: true,
+      useJoinProtocolV2: true,
+    },
+  },
+}))
+jest.mock('../../../src/p2p/NodeList', () => {
+  const actual = jest.requireActual('../../../src/p2p/NodeList')
+  return {
+    ...actual,
+    getByPubKeyMap: jest.fn().mockReturnValue(new Map()),
+    getByIpPortMap: jest.fn().mockReturnValue(new Map()),
+  }
+})
+jest.mock('../../../src/p2p/CycleChain', () => ({
+  newest: {
+    duration: 60,
+    start: 1723322908, // validJoinRequest.nodeInfo.joinRequestTimestamp - 10
+  },
+}))
+jest.mock('../../../src/p2p/Join/logging', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}))
+jest.mock('../../../src/p2p/Join/state', () => ({
+  getAllowBogon: jest.fn().mockReturnValue(true),
+  getSeen: jest.fn().mockReturnValue(new Set()),
+}))
+
+interface ValidateJoinRequestTest {
+  it: string
+  mutation?: object
+  expectedError?: JoinRequestResponse
+  before?: () => void
+}
+
+const runTestsWith = (
+  fn: (jr: JoinRequest) => null | JoinRequestResponse,
+  tests: ValidateJoinRequestTest[]
+): void => {
+  for (const test of tests) {
+    it(test.it, () => {
+      if (test.before) test.before()
+
+      if (test.expectedError?.success) {
+        console.warn('this test is expecting an error, but `success` is expected to be `true`')
+      }
+
+      const joinRequest = {
+        ...validJoinRequest,
+        ...(test.mutation || {}),
+      } as JoinRequest
+
+      const result = fn(joinRequest)
+
+      // seen set needs to be cleared after every test
+      getSeen().clear()
+
+      if (!test.expectedError) {
+        expect(result).toBeNull()
+      } else {
+        expect(result).toStrictEqual(test.expectedError)
+      }
+    })
+  }
+}
+
+const validJoinRequest: JoinRequest = Object.freeze({
+  appJoinData: { adminCert: null, mustUseAdminCert: false, stakeCert: null, version: '1.12.1' },
+  cycleMarker: '45da5452eb8e45d73eee05a973375ef824f43d8a3f67186e24222e3bdd5e7940',
+  nodeInfo: {
+    activeTimestamp: 0,
+    address: '3d173e0ce5ee2c81fd53f810d34093ae33bfeb76b352a05237d3575fc7c23f2d',
+    externalIp: '127.0.0.1',
+    externalPort: 9003,
+    internalIp: '127.0.0.1',
+    internalPort: 10003,
+    joinRequestTimestamp: 1723322918,
+    publicKey: '3d173e0ce5ee2c81fd53f810d34093ae33bfeb76b352a05237d3575fc7c23f2d',
+    readyTimestamp: 0,
+    refreshedCounter: 2,
+    syncingTimestamp: 0,
+  },
+  proofOfWork:
+    '{"compute":{"hash":"28efe69b94cf3786477fdbba8da46bfbf399d02a649da97f6b82b0da8d4d6490","nonce":"f7e6cbce19eef02662e7fc40a8dc8e76f437ba0bd0e9a2dc9f5edfa12e55d754"}}',
+  selectionNum: 'a331b77d1413e3a71181b7a62451c49151fd4c516c2b9e5a778f11d3709feec9',
+  sign: {
+    owner: '3d173e0ce5ee2c81fd53f810d34093ae33bfeb76b352a05237d3575fc7c23f2d',
+    sig: '5e5e8b826526aa3f9b49731e9dc0b2497f1e4c3f1a0dde18920c70e31dc4a12d62f1f0145e39ee9ae2f5351beda0d48a26da816dbbfb6232eb8d5f403443360909b6b3625fafa0f078857197320b63d24d81960f48ec2058a6c8f7be272a8430',
+  },
+  version: packageVersion,
+})
+
+describe('validateJoinRequest', () => {
+  const tests: ValidateJoinRequestTest[] = [
+    {
+      it: 'should pass with valid join request',
+    },
+    {
+      it: 'should fail with older join request version',
+      mutation: {
+        version: '0.0.0',
+      },
+      expectedError: BAD_VERSION_ERROR,
+    },
+    {
+      it: 'should fail with incorrect join request types',
+      mutation: {
+        cycleMarker: 1,
+      },
+      expectedError: BAD_STRUCTURE_ERROR,
+    },
+    {
+      it: 'should fail with invalid signer',
+      mutation: {
+        sign: {
+          ...validJoinRequest.sign,
+          owner: 'invalid owner',
+        },
+      },
+      expectedError: BAD_SIGNATURE_ERROR,
+    },
+    {
+      it: 'should fail with IPv6',
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          externalIp: 'abcd:ef01:2345:6789:abcd:ef01:2345:6789',
+          internalIp: '::',
+        },
+      },
+      expectedError: IPV6_ERROR,
+    },
+    {
+      it: 'should fail with invalid host',
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          externalIp: 'not an address',
+          internalIp: 'also not an address, but not checked',
+        },
+      },
+      expectedError: RESERVED_IP_REJECTED_ERROR,
+    },
+    {
+      it: 'should fail if already seen',
+      before: () => {
+        ;(getSeen as jest.Mock).mockReturnValueOnce(new Set(['already seen']))
+      },
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          publicKey: 'already seen',
+        },
+        sign: {
+          ...validJoinRequest.sign,
+          owner: 'already seen',
+        },
+      },
+      expectedError: ALREADY_SEEN_ERROR,
+    },
+    {
+      it: 'should fail if joining node is known by public key',
+      before: () => {
+        ;(getByPubKeyMap as jest.Mock).mockReturnValueOnce(new Map([['known node', {}]]))
+      },
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          publicKey: 'known node',
+        },
+        sign: {
+          ...validJoinRequest.sign,
+          owner: 'known node',
+        },
+      },
+      expectedError: ALREADY_KNOWN_PK_ERROR,
+    },
+    {
+      it: 'should fail if joining node is known by IP address',
+      before: () => {
+        ;(getByIpPortMap as jest.Mock).mockReturnValueOnce(new Map([['12.34.56.78:90', {}]]))
+      },
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          internalIp: '12.34.56.78',
+          internalPort: 90,
+        },
+      },
+      expectedError: ALREADY_KNOWN_IP_ERROR,
+    },
+    {
+      it: 'should fail with timestamp too early',
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          joinRequestTimestamp: 0,
+        },
+      },
+      expectedError: EARLY_TIMESTAMP_ERROR,
+    },
+    {
+      it: 'should fail with timestamp too late',
+      mutation: {
+        nodeInfo: {
+          ...validJoinRequest.nodeInfo,
+          joinRequestTimestamp: 999999999999999,
+        },
+      },
+      expectedError: LATE_TIMESTAMP_ERROR,
+    },
+  ]
+
+  runTestsWith(validateJoinRequest, tests)
+})
+
+describe('verifyJoinRequestTypes', () => {
+  const tests: ValidateJoinRequestTest[] = [
+    {
+      it: 'should pass when correct types are passed',
+      mutation: {},
+    },
+    {
+      it: 'should fail if cycleMarker is a number',
+      mutation: { cycleMarker: 1 },
+      expectedError: BAD_STRUCTURE_ERROR,
+    },
+    {
+      it: 'should fail if nodeInfo is a string',
+      mutation: { nodeInfo: '192.68.123.123' },
+      expectedError: BAD_STRUCTURE_ERROR,
+    },
+    {
+      it: 'should fail if sign if a string',
+      mutation: { sign: 'i am a hash but i should be an object' },
+      expectedError: BAD_STRUCTURE_ERROR,
+    },
+    {
+      it: 'should fail if version is a number',
+      mutation: { version: 1 },
+      expectedError: BAD_STRUCTURE_ERROR,
+    },
+  ]
+
+  runTestsWith(verifyJoinRequestTypes, tests)
+})
+
+describe('validateVersion', () => {
+  it('should pass with equal join request version', () => {
+    const result = validateVersion(packageVersion)
+    expect(result).toBeNull()
+  })
+  it('should pass with newer join request version', () => {
+    const result = validateVersion('99999.99999.99999')
+    expect(result).toBeNull()
+  })
+  it('should fail with older join request version', () => {
+    const result = validateVersion('0.0.0')
+    expect(result).toStrictEqual(BAD_VERSION_ERROR)
+  })
+})
+
+describe('verifyJoinRequestSigner', () => {
+  const tests = [
+    {
+      it: 'should pass with correct signer',
+      mutation: {},
+      shouldSucceed: true,
+    },
+    {
+      it: 'should fail with wrong signature owner',
+      mutation: {
+        sign: {
+          owner: 'wrong owner',
+        },
+      },
+      expectedError: BAD_SIGNATURE_ERROR,
+    },
+    {
+      it: 'should fail with wrong node public key',
+      mutation: {
+        nodeInfo: {
+          publicKey: 'wrong key',
+        },
+      },
+      expectedError: BAD_SIGNATURE_ERROR,
+    },
+  ]
+  runTestsWith(verifyJoinRequestSigner, tests)
+})
+
+describe('verifyNotIPv6', () => {
+  it('should pass without IPv6', () => {
+    expect(verifyNotIPv6('192.168.1.1')).toBeNull()
+  })
+  it('should fail with IPv6', () => {
+    expect(verifyNotIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toStrictEqual(IPV6_ERROR)
+  })
+})
+
+describe('validateJoinRequestHost', () => {
+  it('should pass with valid IP', () => {
+    expect(validateJoinRequestHost('123.234.123.234')).toBeNull()
+  })
+
+  // test reserved IPs
+  const reservedAddresses = [
+    '0.1.2.3',
+    '192.0.0.100',
+    '192.0.2.4',
+    '198.18.4.5',
+    '198.51.100.5',
+    '203.0.113.60',
+    '224.239.0.2',
+    '239.0.123.123',
+    '240.1.2.3',
+    '254.4.5.6',
+    '255.255.255.255',
+  ]
+  for (const address of reservedAddresses) {
+    it(`should fail with reserved IP ${address}, bogon disallowed`, () => {
+      ;(getAllowBogon as jest.Mock).mockReturnValue(false)
+      expect(validateJoinRequestHost(address)).toStrictEqual(BOGON_NOT_ACCEPTED_ERROR)
+    })
+  }
+  for (const address of reservedAddresses) {
+    it(`should fail with reserved IP ${address}, bogon allowed`, () => {
+      ;(getAllowBogon as jest.Mock).mockReturnValue(true)
+      expect(validateJoinRequestHost(address)).toStrictEqual(RESERVED_IP_REJECTED_ERROR)
+    })
+  }
+
+  // bogon tests
+  const privateAddresses = [
+    '10.1.2.3',
+    '100.64.0.0',
+    '100.127.0.0',
+    '127.0.1.2',
+    '169.254.100.100',
+    '172.16.1.2',
+    '172.31.3.4',
+    '192.168.0.1',
+  ]
+
+  // test with bogon allowed
+  for (const address of privateAddresses) {
+    it(`should pass with private IP ${address}, bogon allowed`, () => {
+      ;(getAllowBogon as jest.Mock).mockReturnValue(true)
+      expect(validateJoinRequestHost(address)).toBeNull()
+    })
+  }
+
+  // test with bogon disallowed
+  for (const address of privateAddresses) {
+    it(`should fail with private IP ${address}, bogon disallowed`, () => {
+      ;(getAllowBogon as jest.Mock).mockReturnValue(false)
+      expect(validateJoinRequestHost(address)).toStrictEqual(BOGON_NOT_ACCEPTED_ERROR)
+    })
+  }
+})
+
+// describe('verifyUnseen', () => {
+//   it('should pass if node is unseen', () => {})
+//   it('should fail if node is already seen', () => {})
+// })
+//
+// describe('verifyNodeUnknown', () => {
+//   it('should pass if joining node is unknown', () => {})
+//   it('should fail if joining node is known', () => {})
+// })
+//
+// describe('validateJoinRequestTimestamp', () => {
+//   it('should pass with correct timestamp', () => {})
+//   it('should fail with invalid timestamp', () => {})
+// })


### PR DESCRIPTION
Adds unit tests for testing `validateJoinRequest` and some of its components.

Refactors were required in order to eliminate any circular dependencies that prevented mock functions from working as intended.

To see this work, just run `npx jest "validateJoinRequest"`.