### PR TITLE
Update Nix flake to pin Node and Rust versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,44 +1,63 @@
 {
   "nodes": {
-    "naersk": {
+    "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1687852486,
-        "narHash": "sha256-2rXkhKUVQxbVaC+TITPpILiy/dSbordOLs87eoWHYxA=",
+        "lastModified": 1723703304,
+        "narHash": "sha256-7ehq0nfRHpU3oNAkRpklaDxQZUpuaUig2sR2LI+IL/U=",
         "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "df10963b956962913b693a638746a95d6c506404",
+        "repo": "fenix",
+        "rev": "6e4233dc54850e8aff6eff401400e9a9343881eb",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "repo": "naersk",
+        "repo": "fenix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687793116,
-        "narHash": "sha256-6xRgZ2E9r/BNam87vMkHJ/0EPTTKzeNwhw3abKilEE4=",
-        "owner": "NixOS",
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e4e0807d2142d17f463b26a8b796b3fe20a3011",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs-node-18": {
       "locked": {
         "lastModified": 1679793451,
         "narHash": "sha256-JafTtgMDATE8dZOImBhWMA9RCn9AP8FVOpN+9K/tTlg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "0cd51a933d91078775b300cf0f29aa3495231aa2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cd51a933d91078775b300cf0f29aa3495231aa2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1723703277,
+        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
         "type": "github"
       },
       "original": {
@@ -64,10 +83,28 @@
     },
     "root": {
       "inputs": {
-        "naersk": "naersk",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-node-18": "nixpkgs-node-18",
         "shardus-cli": "shardus-cli",
         "utils": "utils_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1723648323,
+        "narHash": "sha256-AT6K9JREduWC1zcIJIx8JTZa4sYZD6VvyB/xRnjphqY=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "64a140527b383e3a2fe95908881624fc5374c60c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "shardus-cli": {
@@ -76,11 +113,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1679930458,
-        "narHash": "sha256-wZwQxgLY7PbwAf81Qui3UzASea3Rh6U28SsovkkJWUg=",
+        "lastModified": 1703721509,
+        "narHash": "sha256-7FZekqUXvc4ok42/X/dHGuVuuwM9HtfNqvbchr+SZ3o=",
         "ref": "nix-flake",
-        "rev": "a00575404ff45216c29682c74c4e902d452f8e20",
-        "revCount": 75,
+        "rev": "90a799ac459db797b0b03163e9d7090adf0a9cd9",
+        "revCount": 85,
         "type": "git",
         "url": "https://gitlab.com/shardus/tools/shardus-cli"
       },
@@ -88,6 +125,21 @@
         "ref": "nix-flake",
         "type": "git",
         "url": "https://gitlab.com/shardus/tools/shardus-cli"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "utils": {
@@ -106,12 +158,15 @@
       }
     },
     "utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,51 +3,55 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-node-18.url = "github:NixOS/nixpkgs/0cd51a933d91078775b300cf0f29aa3495231aa2";
     utils.url = "github:numtide/flake-utils";
     shardus-cli.url = "git+https://gitlab.com/shardus/tools/shardus-cli?ref=nix-flake";
-    naersk.url = "github:nix-community/naersk";
+    fenix.url = "github:nix-community/fenix";
   };
 
   outputs = {
     self,
-    naersk,
     nixpkgs,
-    shardus-cli,
+    nixpkgs-node-18,
     utils,
+    shardus-cli,
+    fenix,
+    ...
   }: let
     appName = "shardus-core";
     out =
       utils.lib.eachDefaultSystem
       (system: let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-        buildNodeJs = pkgs.callPackage "${nixpkgs}/pkgs/development/web/nodejs/nodejs.nix" {python = pkgs.python3;};
+        pkgs-node-18 = import nixpkgs-node-18 {inherit system;};
+        pkgs = import nixpkgs {inherit system;};
+
+        # build a custom nodejs at version 18.16.1
+        buildNodeJs = pkgs-node-18.callPackage "${nixpkgs-node-18}/pkgs/development/web/nodejs/nodejs.nix" {python = pkgs-node-18.python3;};
         custom-nodejs = buildNodeJs {
           enableNpm = true;
           version = "18.16.1";
           sha256 = "0wp2xyz5yqcvb6949xaqpan73rfhdc3cdfsvx7vzvzc9in64yh78";
         };
 
-        nativeBuildInputs = with pkgs; [
-          custom-nodejs
+        # also pin rust to 1.74.1
+        custom-rust = fenix.packages.${system}.toolchainOf {
+          channel = "1.74.1";
+          sha256 = "sha256-PjvuouwTsYfNKW5Vi5Ye7y+lL7SsWGBxCtBOOm2z14c=";
+        };
 
-          # rust dependencies for rust dependencies
-          cargo
-        ];
-        buildInputs = with pkgs; [];
+        nativeBuildInputs = [custom-rust.toolchain];
+        buildInputs = [custom-nodejs];
       in {
         # `nix develop` or direnv
         devShell = pkgs.mkShell {
           packages =
             nativeBuildInputs
             ++ buildInputs
-            ++ (with pkgs; [
-              nodePackages.typescript-language-server
-              nodePackages.vscode-langservers-extracted
-              nodePackages.prettier
-
-              shardus-cli.packages.${system}.default
+            ++ [shardus-cli.packages.${system}.default]
+            ++ (with pkgs.nodePackages; [
+              typescript-language-server
+              vscode-langservers-extracted
+              prettier
             ]);
         };
       });


### PR DESCRIPTION
Pins nixpkgs, Node (18.16.1), and Rust (1.74.1) to versions compatible with this repository.

nixpkgs is pinned to an older version for Node v18 to build without failure.