### PR TITLE
fixes for RED-105

### DIFF
--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -142,19 +142,6 @@ export class NetworkClass extends EventEmitter {
     })
   }
 
-  handleError(error: any, req: any, res: any, route: string) {
-    /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Error in route ${route}: ${error.message}`)
-
-    nestedCountersInstance.countEvent('endpoint-exception', `${route}`)
-
-    // Send an error response
-    res.status(500).json({
-      error: 'Internal Server Error',
-      message: isDebugMode() ? error.message : 'An unexpected error occurred',
-      route: route,
-    })
-  }
-
   // TODO: Allow for binding to a specified network interface
   _setupExternal() {
     return new Promise((resolve, reject) => {

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -142,6 +142,19 @@ export class NetworkClass extends EventEmitter {
     })
   }
 
+  handleError(error: any, req: any, res: any, route: string) {
+    /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`Error in route ${route}: ${error.message}`)
+
+    nestedCountersInstance.countEvent('endpoint-exception', `${route}`)
+
+    // Send an error response
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: isDebugMode() ? error.message : 'An unexpected error occurred',
+      route: route,
+    })
+  }
+
   // TODO: Allow for binding to a specified network interface
   _setupExternal() {
     return new Promise((resolve, reject) => {

--- a/src/p2p/Archivers.ts
+++ b/src/p2p/Archivers.ts
@@ -931,17 +931,6 @@ export function registerRoutes() {
   Comms.registerGossipHandler('joinarchiver', async (payload, sender, tracker) => {
     profilerInstance.scopedProfileSectionStart('joinarchiver')
     try {
-      if (
-        !checkGossipPayload(
-          payload,
-          { nodeInfo: 'o', requestType: 's', requestTimestamp: 'n', sign: 'o' },
-          'joinarchiver',
-          sender
-        )
-      ) {
-        return
-      }
-
       if (logFlags.console) console.log('Join request gossip received:', payload)
       const accepted = await addArchiverJoinRequest(payload, tracker, false)
       if (logFlags.console) {

--- a/src/p2p/CycleChain.ts
+++ b/src/p2p/CycleChain.ts
@@ -54,7 +54,16 @@ export function prepend(cycle: P2P.CycleCreatorTypes.CycleRecord) {
     cycles.unshift(cycle)
     cyclesByMarker[marker] = cycle
     oldest = cycle
-    if (!newest){
+
+    // this will happen only once in the lifetime of a node. we never set newest to null
+    if (newest == null){
+      newest = cycle
+    }
+
+    // if our cycle is newer than the newest lets update newest and current cycle marker
+    // this should only be happening before we have started digesting cycles.
+    // but this check will make the actions correct.
+    if(cycle.counter > newest.counter){
       newest = cycle
       currentCycleMarker = marker
     }

--- a/src/p2p/CycleChain.ts
+++ b/src/p2p/CycleChain.ts
@@ -31,6 +31,7 @@ export function reset() {
   cyclesByMarker = {}
   oldest = null
   newest = null
+  currentCycleMarker = null
 }
 
 export function getNewest() {
@@ -53,7 +54,10 @@ export function prepend(cycle: P2P.CycleCreatorTypes.CycleRecord) {
     cycles.unshift(cycle)
     cyclesByMarker[marker] = cycle
     oldest = cycle
-    if (!newest) newest = cycle
+    if (!newest){
+      newest = cycle
+      currentCycleMarker = marker
+    }
   }
 }
 export function validate(

--- a/src/p2p/Join/v2/unjoin.ts
+++ b/src/p2p/Join/v2/unjoin.ts
@@ -21,6 +21,11 @@ export async function submitUnjoin(): Promise<Result<void, Error>> {
     publicKey: crypto.keypair.publicKey,
   })
 
+  const foundInStandbyNodes = getStandbyNodesInfoMap().has(unjoinRequest.publicKey)
+  if (!foundInStandbyNodes) {
+    return err(new Error('node is not in standby. Do not send unjoin request'))
+  }
+
   const archiver = getRandomAvailableArchiver()
   try {
     const activeNodesResult = await getActiveNodesFromArchiver(archiver)

--- a/src/p2p/Lost.ts
+++ b/src/p2p/Lost.ts
@@ -1274,8 +1274,8 @@ async function isDownCheck(node) {
     const resp: { newestCycle: CycleData } = await http.get(`${ip}:${port}/sync-newest-cycle`)
     return resp
   }
-  const resp = await queryExt(node) // if the node is down, reportLost() will set status to 'down'
   try {
+    const resp = await queryExt(node) // if the node is down, reportLost() will set status to 'down'
     if (typeof resp.newestCycle.counter !== 'number') return 'down'
   } catch {
     /* prettier-ignore */ nestedCountersInstance.countEvent('p2p', 'isDownCheck-down-3', 1)

--- a/src/p2p/Utils.ts
+++ b/src/p2p/Utils.ts
@@ -562,7 +562,7 @@ export async function getActiveNodesFromArchiver(
   archiver: ActiveNode
 ): Promise<Result<P2P.P2PTypes.SignedObject<SeedNodesList>, Error>> {
   const nodeInfo = getPublicNodeInfo()
-  return await postToArchiver<unknown, P2P.P2PTypes.SignedObject<SeedNodesList>>(
+  return postToArchiver<unknown, P2P.P2PTypes.SignedObject<SeedNodesList>>(
     archiver,
     'nodelist',
     Context.crypto.sign({
@@ -603,10 +603,10 @@ function isNodeNearRotatingOut(
 }
 
 /**
- * Returns true if a node was recently rotate in or 
+ * Returns true if a node was recently rotate in or
  * will be rotated out soon
- * @param nodeId 
- * @returns 
+ * @param nodeId
+ * @returns
  */
 export function isNodeInRotationBounds(nodeId: string): boolean {
   const { idx, total } = NodeList.getAgeIndexForNodeId(nodeId)

--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -454,7 +454,9 @@ async function sendOldDataToNodes(
     const res = await http.post(
       `${nodesToSendData[i].externalIp}:${nodesToSendData[i].externalPort}/snapshot-data-offer`,
       offer
-    )
+    ).catch((e) => {
+      console.error('Error sending data offer to node', e)
+    })
   }
 }
 
@@ -616,6 +618,10 @@ async function sendOfferToNode(node, offer, isSuggestedByNetwork = false) {
       }
     }
     await http.post(`${node.ip}:${node.port}/snapshot-data`, dataToSend)
+      .catch(e => {
+        log('ERROR: unable to send snapshot data to node')
+        log('ERROR: ', e)
+      })
     // If a node reply us 'try_later', wait X amount of time provided by node (OR) cycleDuration/2
   } else if (answer === P2P.SnapshotTypes.offerResponse.tryLater) {
     const waitTime = res.waitTime || 5 * Context.config.p2p.cycleDuration * 1000

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -891,6 +891,13 @@ class AccountPatcher {
               continue
             }
 
+            // check the length of the radix
+            if (nodeHashes.radix.length !== this.treeSyncDepth) {
+              if (logFlags.error) this.mainLogger.error(`syncTrieHashesBinaryHandler: radix length mismatch: ${nodeHashes.radix}`)
+              nestedCountersInstance.countEvent('accountPatcher', `${route}-radix-length-mismatch`)
+              continue
+            }
+
             // todo: secure that the voter is allowed to vote.
             let hashVote = hashTrieSyncConsensus.radixHashVotes.get(nodeHashes.radix)
             if (hashVote == null) {
@@ -2582,6 +2589,12 @@ class AccountPatcher {
     const minVotes = this.calculateMinVotes()
 
     for (const radix of hashTrieSyncConsensus.radixHashVotes.keys()) {
+      // check the length of the radix
+      if (radix.length !== this.treeSyncDepth) {
+        if (logFlags.error) this.mainLogger.error(`syncTrieHashesBinaryHandler: radix length mismatch: ${radix}`)
+        nestedCountersInstance.countEvent('accountPatcher', `isInsync-radix-length-mismatch`)
+        continue
+      }
       const votesMap = hashTrieSyncConsensus.radixHashVotes.get(radix)
       const ourTrieNode = this.shardTrie.layerMaps[this.treeSyncDepth].get(radix)
       if (logFlags.debug)

--- a/src/state-manager/AccountSync.ts
+++ b/src/state-manager/AccountSync.ts
@@ -1014,7 +1014,7 @@ class AccountSync {
           return r
         } catch (error) {
           console.error('getGlobalAccountReportFromArchiver error', error)
-          null
+          return null
         }
       }
 
@@ -1037,21 +1037,21 @@ class AccountSync {
         return result
       }
       result = result as Partial<GlobalAccountReportResp> & { msg: string }
-      if (result === null) {
+      if (result == null) {
         /* prettier-ignore */ nestedCountersInstance.countEvent('sync', `DATASYNC: getRobustGlobalReport_${tag} result === null`)
         /* prettier-ignore */ if (logFlags.error) this.mainLogger.error(`ASK FAIL getRobustGlobalReport result === null ${resultFromArchiver ? 'archiver:': 'node:'}${utils.stringifyReduce(nodeId)} `)
         result = { ready: false, msg: `result === null: ${Math.random()}` }
         return result
       }
 
-      if (result != null && result.ready === false) {
+      if (result.ready === false) {
         /* prettier-ignore */ nestedCountersInstance.countEvent( 'sync', `DATASYNC: getRobustGlobalReport_${tag} result.ready = false` )
         /* prettier-ignore */ if (logFlags.error) this.mainLogger.error( `ASK FAIL getRobustGlobalReport result.ready === false, result: ${utils.stringifyReduce(result)}` )
         result = { ready: false, msg: `not ready: ${Math.random()}` }
         return result
       }
 
-      if (result != null && result.accounts == null) {
+      if (result.accounts == null) {
         /* prettier-ignore */ nestedCountersInstance.countEvent( 'sync', `DATASYNC: getRobustGlobalReport_${tag} result != null, result.stateHash == null. result: ${utils.stringifyReduce( result )}` )
         /* prettier-ignore */ if (logFlags.error) this.mainLogger.error( `ASK FAIL getRobustGlobalReport result.stateHash == null, result: ${utils.stringifyReduce( result )}` )
         result = { ready: false, msg: `invalid data format: ${Math.random()}` }

--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -1849,7 +1849,7 @@ class TransactionConsenus {
       txId,
       Context.stateManager.currentCycleShardData.parititionShardDataMap
     )
-    const cycleMarker = CycleChain.computeCycleMarker(CycleChain.newest)
+    const cycleMarker = CycleChain.getCurrentCycleMarker()
     const cycleCounter = CycleChain.newest.counter
     /* prettier-ignore */ if (logFlags.verbose) this.mainLogger.debug('Asking timestamp from node', homeNode.node)
 


### PR DESCRIPTION
Fixing the update of newest and currentCycleMarker.  This code before would only update one time per app lifecycle if newest was not set.   See changes and comments, but this has been updates so that we update newest if it is null.   Also we will update newest and currentCycleMarker if our observed cycle is a greater counter than newest.