### PR TITLE
Global Error handling 

### DIFF
--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -99,6 +99,7 @@ export class NetworkClass extends EventEmitter {
     this.useLruCacheForSocketMgmt = config.p2p.useLruCacheForSocketMgmt
     this.lruCacheSizeForSocketMgmt = config.p2p.lruCacheSizeForSocketMgmt
     this.shardusCryptoHashKey = config.crypto.hashKey
+    this.wrapRoutes();
   }
 
   setDebugNetworkDelay(delay: number) {


### PR DESCRIPTION
have tested the error handler against reports like 32982 and 32993 and works great and saves our network/nodes from crashing because of unhandled errors.. some ss to find .. how it'll work against such reports :

eg. report 32982
![image](https://github.com/user-attachments/assets/a43c025d-6b27-4e42-9fb0-176ff6b076f7)
how it'll save.. by throwing internal server error to the user instead of crashing : 
![image](https://github.com/user-attachments/assets/eda6afb9-548a-49fc-af62-3fb882f05737)

eg. report 32993
![image](https://github.com/user-attachments/assets/98d619ac-10fd-4c9f-84b1-98a6a8eadbbb)
in error logs.. you will find logs like the following in case error is encountered.. but we won't be crashing because of unhandled errors :
![image](https://github.com/user-attachments/assets/e60ad46c-c023-4295-a3c3-cfe76a74e7f2)

Ref: https://linear.app/shm/issue/SEC-502/add-global-error-handling-in-shardeum-and-shardus-core-repo-external
