### PR TITLE
BLUE-270: Archiver-IP Issue → uncommented recipient vs client IP check and added more debug logs

### DIFF
--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -514,6 +514,8 @@ class Shardus extends EventEmitter {
             return
           }
           const archiverCreds = JSON.parse(socket.handshake.query.data)
+          console.log('FOR DEBUG PURPOSES: archiverCreds: ')
+          console.dir(archiverCreds, { depth: null })
           const isValidSig = this.crypto.verify(archiverCreds, archiverCreds.publicKey)
           if (!isValidSig) {
             this.mainLogger.error(`❌ Invalid Signature from Archiver @ ${archiverIP}`)
@@ -521,18 +523,23 @@ class Shardus extends EventEmitter {
             return
           }
           const recipient = Archivers.recipients.get(archiverCreds.publicKey)
+          console.log('FOR DEBUG PURPOSES: Archiver Recipients: ')
+          console.dir(Archivers.recipients, { depth: null })
+          console.log('FOR DEBUG PURPOSES: ArchiverIP: ', archiverIP)
+          console.log('FOR DEBUG PURPOSES: Is (Archiver !== recipientIP) Check: ', archiverIP !== recipient.nodeInfo.ip)
+          
           if (!recipient) {
             this.mainLogger.error(`❌ Remote Archiver @ ${archiverIP} is NOT a recipient!`)
             socket.disconnect()
             return
           }
-          // if (archiverIP !== recipient.nodeInfo.ip) {
-          //   this.mainLogger.error(`❌ PubKey & IP mismatch for Archiver @ ${archiverIP} !`)
-          //   this.mainLogger.error('Recipient: ', recipient.nodeInfo)
-          //   this.mainLogger.error('Remote Archiver: ', socket.handshake.address)
-          //   socket.disconnect()
-          //   return
-          // }
+          if (archiverIP !== recipient.nodeInfo.ip) {
+            this.mainLogger.error(`❌ PubKey & IP mismatch for Archiver @ ${archiverIP} !`)
+            this.mainLogger.error('Recipient: ', recipient.nodeInfo)
+            this.mainLogger.error('Remote Archiver: ', socket.handshake.address)
+            socket.disconnect()
+            return
+          }
 
           socket.handshake.query.data = archiverCreds
           next()


### PR DESCRIPTION
### Summary
A false alarm was raised regarding the un-commented logic in this PR, just to be sure of the logic I deployed this branch (**`waternet-debug`**) on the waternet with the same configuration as the earthnet and found no issues in this logic.

HOWEVER, Kaung and Mehdi pointed out a few points of concern in this approach of Auth. They're listed here:
1. **[Mehdi's message regarding reverse proxies of load balancers](https://shardeum.slack.com/archives/C07BK1NCRK6/p1726271547351889?thread_ts=1726264464.585469&cid=C07BK1NCRK6)**

2. **[Kaung's concern regarding Socket connection's header data spoofing, keypair compromise and ipv6 handling.](https://shardeum.slack.com/archives/C07BK1NCRK6/p1726321290237539?thread_ts=1726264464.585469&cid=C07BK1NCRK6)**

### **[Linear Task](https://linear.app/shm/issue/BLUE-270/retain-archiverip-from-the-incoming-socket-connection)**