### PR TITLE
RED-259: add cache for nodelistByStates

### DIFF
--- a/src/p2p/Join/index.ts
+++ b/src/p2p/Join/index.ts
@@ -1635,15 +1635,21 @@ function decideNodeSelection(joinRequest: P2P.JoinTypes.JoinRequest): JoinReques
 }
 
 export function nodelistFromStates(states: P2P.P2PTypes.NodeStatus[]): P2P.NodeListTypes.Node[] {
-  const currentCycle = CycleChain.newest.counter
+  const currentCycle = CycleCreator.currentCycle
   const cacheKey = states.sort().join(',')
 
   if (lastCachedInCycle !== currentCycle) {
-    nodelistCache = new Map(); // Create a new empty cache instead of clearing
-    lastCachedInCycle = currentCycle;
+    if (logFlags.verbose) {
+      nestedCountersInstance.countEvent('p2p', `nodelistFromStates-clear`)
+    }
+    nodelistCache = new Map()
+    lastCachedInCycle = currentCycle
   }
 
   if (nodelistCache.has(cacheKey)) {
+    if (logFlags.verbose) {
+      nestedCountersInstance.countEvent('p2p', `nodelistFromStates-hit`)
+    }
     return nodelistCache.get(cacheKey)!
   }
 
@@ -1668,7 +1674,9 @@ export function nodelistFromStates(states: P2P.P2PTypes.NodeStatus[]): P2P.NodeL
   if (self && !result.some((node) => node.id === self.id)) {
     result.push(self)
   }
-
+  if (logFlags.verbose) {
+    nestedCountersInstance.countEvent('p2p', `nodelistFromStates-set`)
+  }
   nodelistCache.set(cacheKey, result)
 
   return result

--- a/src/p2p/Join/index.ts
+++ b/src/p2p/Join/index.ts
@@ -78,10 +78,7 @@ let mode = null
 
 export let finishedSyncingCycle = -1
 
-type CacheKey = string
-type NodeListCache = Map<CacheKey, P2P.NodeListTypes.Node[]>
-
-let nodelistCache: NodeListCache = new Map()
+let nodelistCache = new Map<string, P2P.NodeListTypes.Node[]>()
 let lastCachedInCycle = -1
 
 // let hasSubmittedJoinRequest = false
@@ -1639,17 +1636,11 @@ export function nodelistFromStates(states: P2P.P2PTypes.NodeStatus[]): P2P.NodeL
   const cacheKey = states.sort().join(',')
 
   if (lastCachedInCycle !== currentCycle) {
-    if (logFlags.verbose) {
-      nestedCountersInstance.countEvent('p2p', `nodelistFromStates-clear`)
-    }
     nodelistCache = new Map()
     lastCachedInCycle = currentCycle
   }
 
   if (nodelistCache.has(cacheKey)) {
-    if (logFlags.verbose) {
-      nestedCountersInstance.countEvent('p2p', `nodelistFromStates-hit`)
-    }
     return nodelistCache.get(cacheKey)!
   }
 
@@ -1673,9 +1664,6 @@ export function nodelistFromStates(states: P2P.P2PTypes.NodeStatus[]): P2P.NodeL
   const self = NodeList.byJoinOrder.find((node) => node.id === Self.id)
   if (self && !result.some((node) => node.id === self.id)) {
     result.push(self)
-  }
-  if (logFlags.verbose) {
-    nestedCountersInstance.countEvent('p2p', `nodelistFromStates-set`)
   }
   nodelistCache.set(cacheKey, result)
 


### PR DESCRIPTION
https://linear.app/shm/issue/RED-259/add-cache-for-nodelistbystatesnodelistfromstates

Has been rebased on RED-103. SHOULD BE MERGED AFTER RED-103

Summary: Implement Caching for nodelistFromStates Function

- caching mechanism for the `nodelistFromStates` function to improve performance.
- `nodelistCache` Map to store cached results.
- Cycle-based cache invalidation using `lastCachedInCycle`.
- tested w/ 20+5 network + rotation + shm-transfer tests