### PR TITLE
SHARD-891 : debugMiddleware query parameters can be partially modified by request submitter or via MITM

### DIFF
--- a/src/network/debugMiddleware.ts
+++ b/src/network/debugMiddleware.ts
@@ -232,7 +232,8 @@ async function handleDebugMultiSigAuth(_req, res, next, authLevel: DevSecurityLe
 
 function stripQueryParams(url: string, params: string[]) {
   // Split the URL into the base and the query string
-  let [base, queryString] = url.split('?')
+  let [base, ...tail] = url.split('?')
+  let queryString = tail.join('?')
 
   // If there's no query string, return the base URL
   if (!queryString) return url


### PR DESCRIPTION
linear : https://linear.app/shm/issue/SHARD-891/[bug-bounty]-35415-[informational]-debugmiddleware-query-parameters

The task involves fixing the operation of the stripQueryParams function to correctly handle the splitting of query parameters, particularly addressing cases where multiple ? characters appear in the URL. This update is necessary to ensure accurate parsing and reconstruction of the query string, maintaining security and functionality in the affected middleware.