### PR TITLE
SHARD-255 Enforce min node limit in consensus

### DIFF
--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -1746,7 +1746,7 @@ class TransactionConsenus {
       }
     }
 
-    const totalNodes = executionGroupNodes.size
+    const totalNodes = Math.max(executionGroupNodes.size, this.config.sharding.nodesPerConsensusGroup)
     const requiredMajority = Math.ceil(totalNodes * this.config.p2p.requiredVotesPercentage)
     return validSignatures >= requiredMajority
   }


### PR DESCRIPTION
Ensure that the # nodes required for validating a txn receipt cannot be < the nodes per conensus group * percent required for consensus.  This is only an issue when we are down to < nodesPerConsensusGroup active nodes in the network.