### PR TITLE
SHARD-1242: Add the nodeId to the app's lostAfterSelection list if it…

### DIFF
--- a/src/p2p/Join/index.ts
+++ b/src/p2p/Join/index.ts
@@ -610,6 +610,7 @@ export function parseRecord(record: P2P.CycleCreatorTypes.CycleRecord): P2P.Cycl
         // if the node has just appeared in startedSyncing or finishedSyncing, do nothing
         if (record.startedSyncing.includes(nodeId)) continue
         if (record.finishedSyncing.includes(nodeId)) continue
+        if (record.lostAfterSelection.includes(nodeId)) continue
 
         // add node to lostAfterSelection to be added to the cycle record next cycle
         lostAfterSelection.push(nodeId)


### PR DESCRIPTION
… is not already in the cycle record's

This should make sure the node id only appears once in the list. The app's lostAfterSelection list eventually gets pushed to the cycle record.