### PR TITLE
Fix/problem node tracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mapbox/node-pre-gyp": "1.0.10",
         "@shardus/crypto-utils": "git+https://github.com/shardeum/lib-crypto-utils#itn4",
         "@shardus/net": "git+https://github.com/shardeum/lib-net#itn4",
-        "@shardus/types": "git+https://github.com/shardeum/lib-types#itn4",
+        "@shardus/types": "git+https://github.com/shardeum/lib-types#itn4-1.16.3",
         "@types/better-sqlite3": "7.6.3",
         "body-parser": "1.18.3",
         "bytenode": "1.3.4",
@@ -1837,7 +1837,7 @@
     },
     "node_modules/@shardus/types": {
       "version": "1.2.21",
-      "resolved": "git+ssh://git@github.com/shardeum/lib-types.git#1d6b6f5d5b185742cf5ce32784cb7068018abaa9",
+      "resolved": "git+ssh://git@github.com/shardeum/lib-types.git#e7b0063490d2885d2f1eaa43d389c5f5dfe6c0fb",
       "license": "ISC"
     },
     "node_modules/@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@mapbox/node-pre-gyp": "1.0.10",
     "@shardus/crypto-utils": "git+https://github.com/shardeum/lib-crypto-utils#itn4",
     "@shardus/net": "git+https://github.com/shardeum/lib-net#itn4",
-    "@shardus/types": "git+https://github.com/shardeum/lib-types#itn4",
+    "@shardus/types": "git+https://github.com/shardeum/lib-types#itn4-1.16.3",
     "@types/better-sqlite3": "7.6.3",
     "body-parser": "1.18.3",
     "bytenode": "1.3.4",
@@ -109,6 +109,9 @@
     "webpack-node-externals": "1.7.2"
   },
   "overrides": {
+    "@shardus/crypto-utils": {
+      "@shardus/types": "git+https://github.com/shardeum/lib-types#itn4-1.16.3"
+    },
     "qs": "6.11.2",
     "ip": "2.0.1",
     "@hapi/hoek": "8.5.1",

--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -71,6 +71,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     maxRotatedPerCycle: 1,
     flexibleRotationDelta: 1,
     flexibleRotationEnabled: false,
+    enableDangerousProblematicNodeRemoval: false,
     enableProblematicNodeRemoval: false,
     enableProblematicNodeRemovalOnCycle: 20000,
     maxProblematicNodeRemovalsPerCycle: 1,

--- a/src/debug/debug.ts
+++ b/src/debug/debug.ts
@@ -148,23 +148,23 @@ class Debug {
     this.network.registerExternalGet('debug_problemNodeTrackerDump', isDebugModeMiddleware, (_, res) => {
       try {
         const dump: Record<string, any> = {}
-        
+        let lastCycle = Context.p2p.state.getLastCycle()
         // Collect data for all nodes that have any refute history
         for (const [nodeId, node] of nodes as Map<string, Node>) {
-          if (node.refuteCycles?.size > 0) {
-            const refuteCycles = Array.from(node.refuteCycles).sort((a, b) => a - b)
+          if (node.refuteCycles?.length > 0) {
+            const refuteCycles = node.refuteCycles
             dump[nodeId] = {
               refuteCycles,
               stats: {
-                refutePercentage: ProblemNodeHandler.getRefutePercentage(node.refuteCycles, currentCycle),
-                consecutiveRefutes: ProblemNodeHandler.getConsecutiveRefutes(refuteCycles, currentCycle),
-                isProblematic: ProblemNodeHandler.isNodeProblematic(node, currentCycle)
+                refutePercentage: ProblemNodeHandler.getRefutePercentage(node.refuteCycles, lastCycle.counter),
+                consecutiveRefutes: ProblemNodeHandler.getConsecutiveRefutes(refuteCycles, lastCycle.counter),
+                isProblematic: ProblemNodeHandler.isNodeProblematic(node, lastCycle.counter)
               }
             }
           }
         }
         
-        res.json({ success: true, data: { nodeHistories: dump } })
+        res.json({ success: true, data: { cycle: lastCycle.counter, nodeHistories: dump } })
       } catch (e) {
         res.json({ success: false, error: e.message })
       }

--- a/src/p2p/ModeSystemFuncs.ts
+++ b/src/p2p/ModeSystemFuncs.ts
@@ -594,16 +594,25 @@ export function getExpiredRemovedV2(
   return { expired, removed }
 }
 
-/** Returns the number of expired nodes and the list of removed nodes using calculateToAcceptV2 
- *  this list includes problematic nodes + expired nodes.
+type GetExpiredRemovedV3Result = {
+  // the number of problematic nodes that we have removed
+  problematic: number
+  // the number of expired nodes that we have removed
+  expired: number
+  // the list of nodes (by id) that we have removed
+  removed: string[]
+}
+
+/** 
+ * Gets the list of nodes that should be removed from the network in the next cycle.
+ * 
 */
 export function getExpiredRemovedV3(
   prevRecord: P2P.CycleCreatorTypes.CycleRecord,
   lastLoggedCycle: number,
   txs: P2P.RotationTypes.Txs & P2P.ApoptosisTypes.Txs,
   info: (...msg: string[]) => void
-): { problematic: number; expired: number; removed: string[] } {
-
+): GetExpiredRemovedV3Result {
   // clear state from last run
   NodeList.potentiallyRemoved.clear()
 
@@ -622,25 +631,20 @@ export function getExpiredRemovedV3(
   const numApoptosizedRemovals = apoptosizedNodesList.length
 
   // expired, non-apoptosized, non-syncing nodes
-  const expiredNodes = NodeList.byJoinOrder.filter((node) => node.activeTimestamp <= expirationTimeThreshold && node.status !== 'syncing' && !apoptosizedNodesList.includes(node.id)).map(node => node.id)
+  const expiredNodes = NodeList.byJoinOrder
+    .filter((node) => {
+      const timestampExpired = node.activeTimestamp <= expirationTimeThreshold
+      const isSyncing = node.status === 'syncing'
+      const isApoptosized = apoptosizedNodesList.includes(node.id)
+      return timestampExpired && !isSyncing && !isApoptosized
+    })
+    .map(node => node.id)
   const numExpiredNodes = expiredNodes.length
-
-  // if its recommended that we dont remove any nodes, we MUST adhere to this. 
-  if (remove === 0) return { problematic: 0, expired: numExpiredNodes, removed: [] }
-
-  // Don't expire/remove any if nodeExpiryAge is negative
-  if (config.p2p.nodeExpiryAge < 0) return { problematic: 0, expired: 0, removed: [] }
-
-  nestedCountersInstance.countEvent(
-    'p2p',
-    `results of getExpiredRemovedV3.calculateToAcceptV2: add: ${add}, remove: ${remove}`
-  )
 
   // Get the set of problematic nodes
   const problematicWithApoptosizedNodes = getProblematicNodes(prevRecord)
   // filter out apoptosized nodes from the problematic nodes
   const problematicNodes = problematicWithApoptosizedNodes.filter(id => !apoptosizedNodesList.includes(id))
-
   const canRemoveProblematicNodesThisCycle = prevRecord.counter % config.p2p.problematicNodeRemovalCycleFrequency === 0
   const numProblematicRemovals = Math.min(
     problematicNodes.length, 
@@ -651,7 +655,7 @@ export function getExpiredRemovedV3(
   // the remainder is the number of expired nodes we can remove this cycle
   // if there are more nodes apopped than we can remove, we can't remove any expired nodes
   const numPotentiallyExpiredRemovals = Math.max(remove - numApoptosizedRemovals, 0)
-  const numExpiredRemovals = Math.min(numPotentiallyExpiredRemovals, numExpiredNodes)
+  const numExpiredRemovals = Math.min(numPotentiallyExpiredRemovals, numExpiredNodes)  
  
   const cycle = CycleChain.newest.counter
 
@@ -669,11 +673,34 @@ export function getExpiredRemovedV3(
         })
     )
   }
-
-  nestedCountersInstance.countEvent(
+  
+  if (logFlags?.node_rotation_debug) {
+    const counters = {
+      add,
+      remove,
+      numApoptosizedRemovals: numApoptosizedRemovals,
+      numProblematicRemovals: numProblematicRemovals,
+      numProblematicNodes: problematicNodes.length,
+      canRemoveProblematicNodesThisCycle: canRemoveProblematicNodesThisCycle,
+      numPotentiallyExpiredRemovals: numPotentiallyExpiredRemovals,
+      numExpiredRemovals: numExpiredRemovals,
+    }
+    nestedCountersInstance.countEvent(
       'p2p',
-      `results of getExpiredRemovedV3: numApoptosizedRemovals: ${numApoptosizedRemovals}, numProblematicRemovals: ${numProblematicRemovals}, numExpiredRemovals: ${numExpiredRemovals}, removed: ${remove}`
-  )
+      `results of getExpiredRemovedV3: ${JSON.stringify(counters)}`
+    )
+  }
+
+  const dangerousRemoval = remove === 0 && config.p2p.enableDangerousProblematicNodeRemoval === false
+  const nodesNeverExpire = config.p2p.nodeExpiryAge < 0
+  // if its recommended that we dont remove any nodes, Or the nodes never expire, we MUST adhere to this.
+  if (dangerousRemoval || nodesNeverExpire) {
+     return { 
+      problematic: 0, 
+      expired: 0, 
+      removed: [] 
+    }
+  }
 
   // array that hold all the nodes to remove
   // maintains the sort order provided in activeByIdOrder
@@ -698,5 +725,5 @@ export function getExpiredRemovedV3(
     insertSorted(removed, node.id)
   }
 
-  return { problematic: problematicNodes.length, expired: numExpiredNodes, removed }
+  return { problematic: numProblematicRemovals, expired: numExpiredRemovals, removed }
 }

--- a/src/p2p/NodeList.ts
+++ b/src/p2p/NodeList.ts
@@ -112,6 +112,12 @@ export function addNode(node: P2P.NodeListTypes.Node, caller: string) {
     return
   }
 
+  if (config.p2p.enableProblematicNodeRemoval) {
+    if (!node.refuteCycles) {
+      node.refuteCycles = [];
+    }
+  }
+
   nodes.set(node.id, node)
   byPubKey.set(node.publicKey, node)
   byIpPort.set(ipPort(node.internalIp, node.internalPort), node)
@@ -314,24 +320,6 @@ export function updateNode(
 ) {
   const node = nodes.get(update.id)
   if (node) {
-    // Initialize refuteCycles if it doesn't exist
-    if (config.p2p.enableProblematicNodeRemoval) {
-      if (cycle.counter >= config.p2p.enableProblematicNodeRemovalOnCycle) {
-        if (!node.refuteCycles) {
-          node.refuteCycles = new Set();
-        }
-        // Track refutes if this update is from a cycle record
-        if (cycle && cycle.refuted?.includes(node.id)) {
-          node.refuteCycles.add(cycle.counter);
-        }
-        
-        // Clean up old refutes using sliding window
-        const windowStart = Math.max(1, cycle.counter - config.p2p.problematicNodeHistoryLength);
-        const oldRefutes = Array.from(node.refuteCycles).filter(c => c < windowStart);
-        oldRefutes.forEach(c => node.refuteCycles.delete(c));
-      }
-    }
-
     // Update node properties
     for (const key of Object.keys(update)) {
       node[key] = update[key]
@@ -386,6 +374,32 @@ export function updateNodes(
   cycle: P2P.CycleCreatorTypes.CycleRecord | null
 ) {
   for (const update of updates) updateNode(update, raiseEvents, cycle)
+}
+
+export function updateProblematicNodeTracking(cycle: P2P.CycleCreatorTypes.CycleRecord | null) {
+  for (const node of nodes.values()) {
+    if (config.p2p.enableProblematicNodeRemoval) {
+      // note: first cut of this had refuteCycles as a set. We need to switch to array, this makes it rotation-safe.
+      // Remove the instanceof check after this is deployed/after itn4 is over.
+      // its also very likely not even necessary.
+      if (!node.refuteCycles || node.refuteCycles instanceof Set) {
+        node.refuteCycles = [];
+      }
+
+      if (cycle.counter >= config.p2p.enableProblematicNodeRemovalOnCycle) {
+        // Track refutes if this update is from a cycle record
+        if (cycle && cycle.refuted?.includes(node.id)) {
+          if (!node.refuteCycles.includes(cycle.counter)) {
+            node.refuteCycles.push(cycle.counter);
+          }
+        }
+        
+        // Clean up old refutes using sliding window
+        const windowStart = Math.max(1, cycle.counter - config.p2p.problematicNodeHistoryLength);
+        node.refuteCycles = node.refuteCycles.filter(c => c >= windowStart);
+      }
+    }
+  }
 }
 
 export function isNodeLeftNetworkEarly(node: P2P.NodeListTypes.Node) {

--- a/src/p2p/ProblemNodeHandler.ts
+++ b/src/p2p/ProblemNodeHandler.ts
@@ -6,9 +6,9 @@ import { Node } from '@shardus/types/build/src/p2p/NodeListTypes';
 export function isNodeProblematic(node: Node, currentCycle: number): boolean {
   if (!node.refuteCycles) return false;
 
-  // Check consecutive refutes
-  const refuteCyclesArray = Array.from(node.refuteCycles as Set<number>).sort((a: number, b: number) => a - b);
-  const consecutiveRefutes = getConsecutiveRefutes(refuteCyclesArray, currentCycle);
+  // Check consecutive refutes  
+  const consecutiveRefutes = getConsecutiveRefutes(node.refuteCycles, currentCycle);
+  
   if (consecutiveRefutes >= config.p2p.problematicNodeConsecutiveRefuteThreshold) {
     return true;
   }
@@ -23,36 +23,57 @@ export function isNodeProblematic(node: Node, currentCycle: number): boolean {
 }
 
 export function getConsecutiveRefutes(refuteCycles: number[], currentCycle: number): number {
-  return refuteCycles[refuteCycles.length - 1] !== currentCycle ? 0 : 
-    refuteCycles.filter((cycle, index) => {
-      return index === 0 || cycle === refuteCycles[index - 1] + 1;
-    }).length;
+  if (refuteCycles.length === 0) return 0;
+  
+  // Filter to only include refutes up to current cycle
+  const relevantRefutes = refuteCycles.filter(cycle => cycle <= currentCycle);
+  if (relevantRefutes.length === 0) return 0;
+  
+  // Find the longest consecutive sequence that ends at current cycle or one before
+  let maxCount = 0;
+  let currentCount = 1;
+  let lastCycle = relevantRefutes[0];
+  
+  for (let i = 1; i < relevantRefutes.length; i++) {
+    const cycle = relevantRefutes[i];
+    
+    if (cycle === lastCycle + 1) {
+      currentCount++;
+    } else {
+      // If sequence breaks, check if previous sequence ended at current cycle or one before
+      if (lastCycle === currentCycle || lastCycle === currentCycle - 1) {
+        maxCount = Math.max(maxCount, currentCount);
+      }
+      currentCount = 1;
+    }
+    
+    lastCycle = cycle;
+  }
+  
+  // Check the last sequence
+  if (lastCycle === currentCycle || lastCycle === currentCycle - 1) {
+    maxCount = Math.max(maxCount, currentCount);
+  }
+  
+  return maxCount;
 }
 
-export function getRefutePercentage(refuteCycles: Set<number>, currentCycle: number): number {
-  const windowStart = Math.max(1, currentCycle - config.p2p.problematicNodeHistoryLength + 1);
+export function getRefutePercentage(refuteCycles: number[], currentCycle: number): number {
+  const windowStart = Math.max(1, currentCycle - config.p2p.problematicNodeHistoryLength);
   const windowSize = Math.min(config.p2p.problematicNodeHistoryLength, currentCycle);
-  const recentRefutes = Array.from(refuteCycles)
+  const recentRefutes = refuteCycles
     .filter(cycle => cycle >= windowStart && cycle <= currentCycle).length;
   
   return recentRefutes / windowSize;
 }
 
 export function getProblematicNodes(prevRecord: P2P.CycleCreatorTypes.CycleRecord): string[] {
-  const problematicNodes = new Set<string>();
-  
-  for (const node of NodeList.activeByIdOrder) {
-    if (isNodeProblematic(node as Node, prevRecord.counter)) {
-      problematicNodes.add(node.id);
-    }
-  }
-
+  const problematicNodes = NodeList.activeByIdOrder.filter(node => isNodeProblematic(node as Node, prevRecord.counter));
+    
   // Sort by refute percentage
-  return Array.from(problematicNodes).sort((a, b) => {
-    const nodeA = NodeList.nodes.get(a) as Node;
-    const nodeB = NodeList.nodes.get(b) as Node;
-    const percentageA = getRefutePercentage(nodeA.refuteCycles, prevRecord.counter);
-    const percentageB = getRefutePercentage(nodeB.refuteCycles, prevRecord.counter);
+  return problematicNodes.sort((a, b) => {
+    const percentageA = getRefutePercentage(a.refuteCycles, prevRecord.counter);
+    const percentageB = getRefutePercentage(b.refuteCycles, prevRecord.counter);
     return percentageB - percentageA;
-  });
+  }).map(node => node.id);
 } 

--- a/src/p2p/Rotation.ts
+++ b/src/p2p/Rotation.ts
@@ -96,8 +96,8 @@ export function updateRecord(
     record.removed = removed // already sorted
   } else {
     const { expired, removed, problematic } = getExpiredRemovedV3(prev, lastLoggedCycle, txs, info)
-    nestedCountersInstance.countEvent('p2p', `results of getExpiredRemovedV2: expired: ${expired} removed: ${removed.length} problematic: ${problematic}`, 1)
-    /* prettier-ignore */ if(logFlags?.node_rotation_debug) logger.mainLog_debug('GETEXPIREDREMOVEDV3_STATS', `results of getExpiredRemovedV2: expired: ${expired} removed: ${removed.length} problematic: ${problematic}`)
+    nestedCountersInstance.countEvent('p2p', `results of getExpiredRemovedV3: expired: ${expired} removed: ${removed.length} problematic: ${problematic}`, 1)
+    /* prettier-ignore */ if(logFlags?.node_rotation_debug) logger.mainLog_debug('GETEXPIREDREMOVEDV3_STATS', `results of getExpiredRemovedV3: expired: ${expired} removed: ${removed.length} problematic: ${problematic}`)
       // record.problematic = problematic // may want to write this to cycle record for
     record.expired = expired
     record.removed = removed // already sorted

--- a/src/p2p/Sync.ts
+++ b/src/p2p/Sync.ts
@@ -486,6 +486,7 @@ function applyNodeListChange(
     'applyNodeListChange'
   )
   NodeList.updateNodes(change.updated, raiseEvents, cycle)
+  NodeList.updateProblematicNodeTracking(cycle)
   if (change.removed[0] !== 'all') NodeList.removeNodes(change.removed, raiseEvents, cycle)
 }
 

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -759,6 +759,8 @@ export interface ServerConfiguration {
     /** Problematic Node configurations */
     /** enable problematic node removal */
     enableProblematicNodeRemoval?: boolean
+    /** when true, we will remove problematic nodes even when calculateToAcceptV2 says we should not remove any nodes. This is useful in development when testing this feature. */
+    enableDangerousProblematicNodeRemoval?: boolean
     /** enable problematic node removal on a specific cycle. This is to allow the network to stabilize before removing problematic nodes. 
      * enableProblematicNodeRemoval must be true for this to take effect*/
     enableProblematicNodeRemovalOnCycle?: number

--- a/test/unit/src/p2p/ProblemNodeHandler.test.ts
+++ b/test/unit/src/p2p/ProblemNodeHandler.test.ts
@@ -55,7 +55,7 @@ describe('ProblemNodeHandler', () => {
     // Create a mock node for testing
     mockNode = {
       ...baseMockNode,
-      refuteCycles: new Set<number>(),
+      refuteCycles: [],
     }
 
     // Clear NodeList mocks before each test
@@ -70,49 +70,65 @@ describe('ProblemNodeHandler', () => {
     })
 
     it('should return true if node has consecutive refutes above threshold', () => {
-      mockNode.refuteCycles = new Set([98, 99, 100])
+      mockNode.refuteCycles = [98, 99, 100]
       expect(isNodeProblematic(mockNode, 100)).toBe(true)
     })
 
     it('should return false if consecutive refutes are below threshold', () => {
-      mockNode.refuteCycles = new Set([97, 98, 99])
+      mockNode.refuteCycles = [98, 99]
       expect(isNodeProblematic(mockNode, 100)).toBe(false)
     })
 
     it('should return true if refute percentage is above threshold', () => {
       // Add 11 refutes in last 100 cycles (11%)
       for (let i = 90; i <= 100; i++) {
-        mockNode.refuteCycles.add(i)
+        mockNode.refuteCycles?.push(i)
       }
       expect(isNodeProblematic(mockNode, 100)).toBe(true)
     })
 
     it('should return false if refute percentage is below threshold', () => {
       // Add 9 refutes in last 100 cycles (9%), spread out to avoid consecutive threshold
-      mockNode.refuteCycles.add(10)
-      mockNode.refuteCycles.add(20)
-      mockNode.refuteCycles.add(30)
-      mockNode.refuteCycles.add(40)
-      mockNode.refuteCycles.add(50)
-      mockNode.refuteCycles.add(60)
-      mockNode.refuteCycles.add(70)
-      mockNode.refuteCycles.add(80)
-      mockNode.refuteCycles.add(90)
+      mockNode.refuteCycles?.push(10)
+      mockNode.refuteCycles?.push(20)
+      mockNode.refuteCycles?.push(30)
+      mockNode.refuteCycles?.push(40)
+      mockNode.refuteCycles?.push(50)
+      mockNode.refuteCycles?.push(60)
+      mockNode.refuteCycles?.push(70)
+      mockNode.refuteCycles?.push(80)
+      mockNode.refuteCycles?.push(90)
       expect(isNodeProblematic(mockNode, 100)).toBe(false)
     })
   })
 
   describe('getConsecutiveRefutes', () => {
-    it('should return 0 if current cycle is not in refutes', () => {
-      expect(getConsecutiveRefutes([97, 98, 99], 100)).toBe(0)
+    it('should return 0 if current cycle is more than 1 cycle ahead of last refute', () => {
+      expect(getConsecutiveRefutes([97, 98, 99], 101)).toBe(0)
     })
 
-    it('should count consecutive refutes up to current cycle', () => {
+    it('should count consecutive refutes ending at current cycle', () => {
       expect(getConsecutiveRefutes([98, 99, 100], 100)).toBe(3)
     })
 
-    it('should only count consecutive sequences', () => {
-      expect(getConsecutiveRefutes([97, 99, 100], 100)).toBe(2)
+    it('should count consecutive refutes ending one cycle before current cycle', () => {
+      expect(getConsecutiveRefutes([98, 99, 100], 101)).toBe(3)
+    })
+
+    it('should only count the most recent consecutive sequence ending at or one before current cycle', () => {
+      expect(getConsecutiveRefutes([95, 96, 97, 99, 100], 101)).toBe(2)
+    })
+
+    it('should handle non-consecutive sequences ending at current cycle', () => {
+      expect(getConsecutiveRefutes([97, 98, 100], 100)).toBe(1)
+    })
+
+    it('should handle non-consecutive sequences ending one before current cycle', () => {
+      expect(getConsecutiveRefutes([97, 98, 100], 101)).toBe(1)
+    })
+
+    it('should not count future cycles', () => {
+      expect(getConsecutiveRefutes([98, 99, 101], 100)).toBe(2)
     })
 
     it('should handle empty refute array', () => {
@@ -122,26 +138,41 @@ describe('ProblemNodeHandler', () => {
     it('should handle single refute at current cycle', () => {
       expect(getConsecutiveRefutes([100], 100)).toBe(1)
     })
+
+    it('should handle single refute one cycle before current cycle', () => {
+      expect(getConsecutiveRefutes([99], 100)).toBe(1)
+    })
+
+    it('should handle multiple non-consecutive sequences', () => {
+      expect(getConsecutiveRefutes([95, 96, 98, 99, 100], 100)).toBe(3)
+    })
+    it('counts the current cycle if it is a refute', () => {
+      expect(getConsecutiveRefutes([98, 99, 100], 100)).toBe(3)
+    })
+    it('gives 0 count if cycle number is -1', () => {
+      expect(getConsecutiveRefutes([98, 99, 100], -1)).toBe(0)
+    })
   })
 
   describe('getRefutePercentage', () => {
     it('should calculate correct percentage in full window', () => {
-      const refuteCycles = new Set([96, 97, 98, 99, 100])
+      const refuteCycles = [96, 97, 98, 99, 100]
       expect(getRefutePercentage(refuteCycles, 100)).toBe(0.05) // 5/100 = 5%
     })
 
     it('should handle empty refute set', () => {
-      const refuteCycles = new Set<number>()
+      const refuteCycles = []
       expect(getRefutePercentage(refuteCycles, 100)).toBe(0)
     })
 
     it('should only count refutes within window', () => {
-      const refuteCycles = new Set([1, 2, 98, 99, 100, 100])
-      expect(getRefutePercentage(refuteCycles, 102)).toBe(0.03) // Only counting 98,99,100
+      const refuteCycles = [1, 2, 98, 99, 100]
+      expect(getRefutePercentage(refuteCycles, 102)).toBe(0.04) // 2, 98, 99, 100
+      expect(getRefutePercentage(refuteCycles, 103)).toBe(0.03) // Only counting 98,99,100
     })
 
     it('should handle early cycles with smaller window', () => {
-      const refuteCycles = new Set([1, 2, 3])
+      const refuteCycles = [1, 2, 3]
       expect(getRefutePercentage(refuteCycles, 3)).toBe(1) // 3/3 = 100%
     })
   })
@@ -165,7 +196,7 @@ describe('ProblemNodeHandler', () => {
       // Add a non-problematic node
       const node: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([90]), // Only 1% refute rate
+        refuteCycles: [90], // Only 1% refute rate
       }
 
       NodeList.activeByIdOrder.push(node)
@@ -179,17 +210,20 @@ describe('ProblemNodeHandler', () => {
       // Create nodes with different refute percentages
       const node1: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([2, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]), // 11% refute rate
+        id: 'node1',
+        refuteCycles: [2, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100], // 11% refute rate
       }
 
       const node2: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([90, 92, 94, 96, 98, 100]), // 6% refute rate
+        id: 'node2',
+        refuteCycles: [90, 92, 94, 96, 98, 100], // 6% refute rate
       }
 
       const node3: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([98, 99, 100]), // 3% refute rate but 3 consecutive
+        id: 'node3',
+        refuteCycles: [98, 99, 100], // 3% refute rate but 3 consecutive
       }
 
       // Add nodes to NodeList mock
@@ -198,6 +232,7 @@ describe('ProblemNodeHandler', () => {
       NodeList.nodes.set(node2.id, node2)
       NodeList.nodes.set(node3.id, node3)
 
+      console.log(NodeList.activeByIdOrder, mockCycleRecord)
       const result = getProblematicNodes(mockCycleRecord)
       // Should contain node1 (11% refutes) and node3 (3 consecutive refutes)
       // Sorted by refute percentage (node1 first, then node3)
@@ -212,7 +247,7 @@ describe('ProblemNodeHandler', () => {
     it('should identify nodes with consecutive refutes', () => {
       const node: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([98, 99, 100]), // 3 consecutive refutes
+        refuteCycles: [98, 99, 100], // 3 consecutive refutes
       }
 
       NodeList.activeByIdOrder.push(node)
@@ -225,11 +260,11 @@ describe('ProblemNodeHandler', () => {
     it('should identify nodes with high refute percentage', () => {
       const node: Node = {
         ...baseMockNode,
-        refuteCycles: new Set(), // Will add 11 refutes (11%)
+        refuteCycles: [], // Will add 11 refutes (11%)
       }
 
       for (let i = 90; i <= 100; i++) {
-        node.refuteCycles.add(i)
+        node.refuteCycles?.push(i)
       }
 
       NodeList.activeByIdOrder.push(node)
@@ -242,7 +277,7 @@ describe('ProblemNodeHandler', () => {
     it('should not include nodes that are neither consecutive nor percentage problematic', () => {
       const node: Node = {
         ...baseMockNode,
-        refuteCycles: new Set([95, 97, 99]), // Non-consecutive and only 3%
+        refuteCycles: [95, 97, 99], // Non-consecutive and only 3%
       }
 
       NodeList.activeByIdOrder.push(node)


### PR DESCRIPTION
# Problem Node Tracker Bug Fixes

## Issue 1: Inconsistent Node Update Triggers
### Problem
- `updateNode` was not being called every cycle for every node
- Only called when there are changes to node properties
- Critical issue: nodes being marked as refuted/lost did not trigger an `updateNode` call
- This led to incomplete tracking of problematic nodes

### Solution
- Added `updateProblematicNodeTracking` in two strategic locations:
  1. Inside [`Sync::applyNodeListChange`](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/Sync.ts#L486-L491)
  2. During node updates via [`NodeList.updateProblematicNodeTracking`](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L379-L405)
- This ensures consistent tracking regardless of node state changes
- Key implementation details:
  - [Tracking function implementation](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L379-L405)
  - [Integration with Sync module](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/Sync.ts#L486-L491)

## Issue 2: Initialization Timing Problem
### Problem
- `refuteCycles` initialization in `updateNode` was problematic
- Nodes could exist without initialized `refuteCycles`
- Activation cycle check was causing initialization delays

### Solution
- Moved initialization to [`addNode` function](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L115-L119)
- Removed activation cycle check
- Initialize immediately if problematic node tracking is enabled
- Ensures consistent state from node creation
- Key changes:
  - [Initialization code](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L115-L119)
  - [Configuration flag check](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/config/server.ts#L71-L77)

## Issue 3: Serialization Issue
### Problem
- NodeList gossip mechanism broken due to `Set` serialization
- `refuteCycles` as `Set` couldn't be properly transmitted

### Solution
- Changed `refuteCycles` from `Set` to `Array`
- Ensures proper serialization during gossip
- Maintains chronological order of refute cycles
- Improves rotation safety
- Implementation details:
  - [Array conversion check](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L386-L388)
  - [Updated problematic node handling](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/ProblemNodeHandler.ts#L6-L24)
  - [Array-based refute tracking](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/p2p/NodeList.ts#L394-L397)

## Implementation Notes
- These changes are interdependent and should be deployed together
- The switch from `Set` to `Array` requires careful handling of duplicates
- Performance impact should be minimal as array operations are still O(n)
- Migration path includes automatic conversion from `Set` to `Array` for existing nodes
- Key configuration:
  - [Server configuration updates](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/config/server.ts#L71-L77)
  - [Type definitions](https://github.com/shardeum/shardus-core/blob/bf4c075419ea15f7905c4c7149e40b1351c9f40d/src/shardus/shardus-types.ts#L759-L766) 