### PR TITLE
SHARD - 1882_related : add txId from the proposal to the proposal hash

### DIFF
--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -3878,11 +3878,12 @@ class TransactionConsenus {
     const applyStatus = {
       applied: proposal.applied,
       cantApply: proposal.cant_preApply,
+      txId: proposal.txid,
     }
     const accountsHash = this.crypto.hash(
       this.crypto.hash(proposal.accountIDs) +
-      this.crypto.hash(proposal.beforeStateHashes) +
-      this.crypto.hash(proposal.afterStateHashes)
+        this.crypto.hash(proposal.beforeStateHashes) +
+        this.crypto.hash(proposal.afterStateHashes)
     )
     const proposalHash = this.crypto.hash(
       this.crypto.hash(applyStatus) + accountsHash + proposal.appReceiptDataHash


### PR DESCRIPTION
Linear Task : https://linear.app/shm/issue/SHARD-1882/archiver-is-trusting-single-connected-validator-in-original-tx-flow#comment-fdfe2a52

Related Comment : https://linear.app/shm/issue/SHARD-1882/archiver-is-trusting-single-connected-validator-in-original-tx-flow#comment-fdfe2a52

