### PR TITLE
fix: get tests passing

### DIFF
--- a/test/unit/src/types/AllowedArchiverResponse.test.ts
+++ b/test/unit/src/types/AllowedArchiverResponse.test.ts
@@ -1,12 +1,10 @@
 import { verifyPayload } from '../../../../src/types/ajv/Helpers';
 import { AJVSchemaEnum } from '../../../../src/types/enum/AJVSchemaEnum';
 import { initAjvSchemas } from '../../../../src/types/ajv/Helpers'
-import { initAllowedArchiverResponse } from '../../../../src/types/ajv/AllowedArchiverResponse'
 
 describe('AllowedArchiverResponse Validation', () => {
     beforeAll(() => {
         initAjvSchemas();
-        initAllowedArchiverResponse();
     });
 
     test('should validate a correct AllowedArchiverResponse', () => {


### PR DESCRIPTION
# Fix duplicate schema registration in AllowedArchiverResponse tests

## Problem
The `AllowedArchiverResponse` test suite was failing due to an attempt to register the same schema twice. This occurred because:
1. `initAjvSchemas()` internally calls `initAllowedArchiverResponse()`
2. The test file was explicitly calling `initAllowedArchiverResponse()` again
3. The schema registration system is designed to prevent duplicate registrations, throwing an error when attempted

## Solution
Removed the redundant call to `initAllowedArchiverResponse()` in the test file since it's already being called by `initAjvSchemas()`. This ensures the schema is registered exactly once while maintaining all the validation functionality.

## Changes
- Removed import of `initAllowedArchiverResponse`
- Removed explicit call to `initAllowedArchiverResponse()` in `beforeAll`

## Testing
All tests in `AllowedArchiverResponse.test.ts` now pass successfully:
- ✓ should validate a correct AllowedArchiverResponse
- ✓ should invalidate a response with missing allowedArchivers
- ✓ should invalidate a response with missing signatures
- ✓ should invalidate a response with incorrect data types
- ✓ should invalidate a response with additional properties

## Additional Notes
This change highlights the importance of understanding initialization flows in the codebase to avoid redundant operations. The fix maintains the same validation behavior while removing the duplicate initialization that was causing the error.