### PR TITLE
SHARD-1926: Add afterStateHash to receipt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mapbox/node-pre-gyp": "1.0.10",
         "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
         "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-        "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+        "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
         "@types/better-sqlite3": "7.6.3",
         "body-parser": "1.18.3",
         "bytenode": "1.3.4",
@@ -1823,6 +1823,11 @@
         "node": "18.19.1"
       }
     },
+    "node_modules/@shardeum-foundation/lib-crypto-utils/node_modules/@shardeum-foundation/lib-types": {
+      "version": "1.3.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.1.tgz",
+      "integrity": "sha512-GnWjMWtWij5+HY+nf3l16nYymvTG8HGSH9iw7SNN8bsnyt4UXvty5nhmA6vMvK/zOQzwW+7jsLnMw29RHSiSIg=="
+    },
     "node_modules/@shardeum-foundation/lib-net": {
       "version": "1.5.0-prerelease.1",
       "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-net/-/lib-net-1.5.0-prerelease.1.tgz",
@@ -1837,9 +1842,9 @@
       }
     },
     "node_modules/@shardeum-foundation/lib-types": {
-      "version": "1.3.0-prerelease.1",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.1.tgz",
-      "integrity": "sha512-GnWjMWtWij5+HY+nf3l16nYymvTG8HGSH9iw7SNN8bsnyt4UXvty5nhmA6vMvK/zOQzwW+7jsLnMw29RHSiSIg=="
+      "version": "1.3.0-prerelease.2",
+      "resolved": "https://registry.npmjs.org/@shardeum-foundation/lib-types/-/lib-types-1.3.0-prerelease.2.tgz",
+      "integrity": "sha512-+1mZcyrcKjptLtU9qOfVeLkiahxyQu4wfI3WCudpH/adR0FrE80TZlF2gJ+aNkyxf6HTdZ8HNYQd5twZBE6Eqw=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@shardeum-foundation/lib-crypto-utils": "4.2.0-prerelease.1",
     "@shardeum-foundation/lib-net": "1.5.0-prerelease.1",
-    "@shardeum-foundation/lib-types": "1.3.0-prerelease.1",
+    "@shardeum-foundation/lib-types": "1.3.0-prerelease.2",
     "@hapi/sntp": "3.1.1",
     "@mapbox/node-pre-gyp": "1.0.10",
     "@types/better-sqlite3": "7.6.3",

--- a/src/p2p/GlobalAccounts.ts
+++ b/src/p2p/GlobalAccounts.ts
@@ -101,7 +101,29 @@ export function init() {
   Comms.registerGossipHandler(setGlobalGossipRoute.name, setGlobalGossipRoute.handler)
 }
 
-export function setGlobal(address, addressHash, value, when, source) {
+/**
+ * Sets a global account by creating and broadcasting a transaction.
+ *
+ * This function performs the following steps:
+ * 1. Logs the initiation of the setGlobal process if console logging is enabled.
+ * 2. Checks if the current node is active. If not, logs a message and returns.
+ * 3. Creates a transaction (`tx`) for setting a global account with the provided parameters.
+ * 4. Signs the transaction (`signedTx`).
+ * 5. Checks if the state manager is available and logs the state.
+ * 6. Determines the nodes to which the transaction will be broadcasted.
+ * 7. Finds the home node and consensus group for the current node.
+ * 8. Removes the current node from the consensus group.
+ * 9. Sets up a timeout and receipt handling mechanism to process receipts or handle timeouts.
+ * 10. Broadcasts the transaction to the consensus group to trigger the creation of a receipt collection.
+ *
+ * @param address - The address of the global account to set.
+ * @param addressHash - The hash of the address.
+ * @param value - The value to set for the global account.
+ * @param when - The timestamp or condition when the value should be set.
+ * @param source - The source node initiating the transaction.
+ * @param afterStateHash - The state hash after the transaction is applied.
+ */
+export function setGlobal(address, addressHash, value, when, source, afterStateHash) {
   if (logFlags.console) console.log(`SETGLOBAL: WE ARE: ${Self.id.substring(0, 5)}`)
 
   // Only do this if you're active
@@ -112,7 +134,15 @@ export function setGlobal(address, addressHash, value, when, source) {
 
   // Create a tx for setting a global account
   const txHash = Context.shardus.app.calculateTxId(value as OpaqueTransaction)
-  const tx: P2P.GlobalAccountsTypes.SetGlobalTx = { address, addressHash, value, when, source, txId: txHash }
+  const tx: P2P.GlobalAccountsTypes.SetGlobalTx = {
+    address,
+    addressHash,
+    value,
+    when,
+    source,
+    txId: txHash,
+    afterStateHash,
+  }
 
   // Sign tx
   const signedTx: P2P.GlobalAccountsTypes.SignedSetGlobalTx = Context.crypto.sign(tx)

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -3378,8 +3378,18 @@ class Shardus extends EventEmitter {
     }
   }
 
-  setGlobal(address, addressHash, value, when, source) {
-    GlobalAccounts.setGlobal(address, addressHash, value, when, source)
+  /**
+   * Sets a global account value using the GlobalAccont Class' setGlobal function.
+   *
+   * @param address - The address of the account.
+   * @param addressHash - The hash of the address.
+   * @param value - The value to set for the account.
+   * @param when - The timestamp or condition when the value should be set.
+   * @param source - The source of the value.
+   * @param afterStateHash - The state hash after setting the value.
+   */
+  setGlobal(address, addressHash, value, when, source, afterStateHash) {
+    GlobalAccounts.setGlobal(address, addressHash, value, when, source, afterStateHash)
   }
 
   getDebugModeMiddleware() {

--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -3700,7 +3700,6 @@ class TransactionConsenus {
           // note this is going to stomp the hash value for the account
           // this used to happen in dapp.updateAccountFull  we now have to save off prevStateId on the wrappedResponse
           //We have to update the hash now! Not sure if this is the greatest place but it needs to be done
-          console.log("[1926d] The wrappedState object here is", wrappedState.data)
           const updatedHash = this.app.calculateAccountHash(wrappedState.data)
           wrappedState.stateId = updatedHash
 

--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -3700,6 +3700,7 @@ class TransactionConsenus {
           // note this is going to stomp the hash value for the account
           // this used to happen in dapp.updateAccountFull  we now have to save off prevStateId on the wrappedResponse
           //We have to update the hash now! Not sure if this is the greatest place but it needs to be done
+          console.log("[1926d] The wrappedState object here is", wrappedState.data)
           const updatedHash = this.app.calculateAccountHash(wrappedState.data)
           wrappedState.stateId = updatedHash
 

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -7652,9 +7652,6 @@ class TransactionQueue {
         hash: account.data.stateId,
         isGlobal,
       } as Shardus.AccountsCopy
-      console.log('[1926a] The account copy here is', accountCopy)
-      console.log('[1926b] The account.data object here is', account.data)
-      console.log('[1926c] The account.data.data object here is', account.data.data)
       accountsToAdd[account.accountId] = accountCopy
     }
     

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -7647,11 +7647,14 @@ class TransactionQueue {
       const isGlobal = this.stateManager.accountGlobals.isGlobalAccount(account.accountId)
       const accountCopy = {
         accountId: account.accountId,
-        data: account.data.data,
+        data: account.data,
         timestamp: account.timestamp,
         hash: account.data.stateId,
-        isGlobal
+        isGlobal,
       } as Shardus.AccountsCopy
+      console.log('[1926a] The account copy here is', accountCopy)
+      console.log('[1926b] The account.data object here is', account.data)
+      console.log('[1926c] The account.data.data object here is', account.data.data)
       accountsToAdd[account.accountId] = accountCopy
     }
     

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -7647,7 +7647,7 @@ class TransactionQueue {
       const isGlobal = this.stateManager.accountGlobals.isGlobalAccount(account.accountId)
       const accountCopy = {
         accountId: account.accountId,
-        data: account.data,
+        data: account.data.data,
         timestamp: account.timestamp,
         hash: account.data.stateId,
         isGlobal,

--- a/src/types/MakeReceipReq.ts
+++ b/src/types/MakeReceipReq.ts
@@ -17,6 +17,7 @@ export type MakeReceiptReq = {
   when: number
   source: string
   txId: string
+  afterStateHash: string
 }
 
 export function serializeMakeReceiptReq(stream: VectorBufferStream, obj: MakeReceiptReq, root = false): void {
@@ -32,6 +33,7 @@ export function serializeMakeReceiptReq(stream: VectorBufferStream, obj: MakeRec
   stream.writeBigUInt64(BigInt(obj.when))
   stream.writeString(obj.source)
   stream.writeString(obj.txId)
+  stream.writeString(obj.afterStateHash)
 }
 
 export function deserializeMakeReceiptReq(stream: VectorBufferStream): MakeReceiptReq {
@@ -50,6 +52,7 @@ export function deserializeMakeReceiptReq(stream: VectorBufferStream): MakeRecei
     when: Number(stream.readBigUInt64()),
     source: stream.readString(),
     txId: stream.readString(),
+    afterStateHash: stream.readString(),
   }
   const errors = verifyPayload(AJVSchemaEnum.MakeReceiptReq, obj)
   if (errors && errors.length > 0) {

--- a/test/unit/src/types/MakeReceiptReq.test.ts
+++ b/test/unit/src/types/MakeReceiptReq.test.ts
@@ -168,6 +168,7 @@ describe('MakeReceiptReq Tests', () => {
       stream.writeBigUInt64(BigInt(obj.when))
       stream.writeString(obj.source)
       stream.writeString(obj.txId)
+      stream.writeString(obj.afterStateHash)
       stream.position = 0 // Reset stream position to read from the beginning
       const result = deserializeMakeReceiptReq(stream)
       expect(result).toEqual(obj)
@@ -196,6 +197,7 @@ describe('MakeReceiptReq Tests', () => {
       stream.writeBigUInt64(BigInt(obj.when))
       stream.writeString(obj.source)
       stream.writeString(obj.txId)
+      stream.writeString(obj.afterStateHash)
       stream.position = 0 // Reset stream position to read from the beginning
       const result = deserializeMakeReceiptReq(stream)
       expect(result).toEqual(obj)
@@ -224,6 +226,7 @@ describe('MakeReceiptReq Tests', () => {
       stream.writeBigUInt64(BigInt(obj.when))
       stream.writeString(obj.source)
       stream.writeString(obj.txId)
+      stream.writeString(obj.afterStateHash)
       stream.position = 0 // Reset stream position to read from the beginning
       const result = deserializeMakeReceiptReq(stream)
       expect(result).toEqual(obj)

--- a/test/unit/src/types/MakeReceiptReq.test.ts
+++ b/test/unit/src/types/MakeReceiptReq.test.ts
@@ -32,6 +32,7 @@ describe('MakeReceiptReq Tests', () => {
         when: 1234567890,
         source: 'source123',
         txId: 'txId123',
+        afterStateHash: 'afterStateHash123',
       }
       serializeMakeReceiptReq(stream, obj, false)
       stream.position = 0 // Reset stream position to read from the beginning
@@ -57,6 +58,7 @@ describe('MakeReceiptReq Tests', () => {
         when: 1234567890,
         source: 'source123',
         txId: 'txId123',
+        afterStateHash: 'afterStateHash123',
       }
       serializeMakeReceiptReq(stream, obj, true)
       stream.position = 0 // Reset stream position to read from the beginning
@@ -83,6 +85,7 @@ describe('MakeReceiptReq Tests', () => {
         when: 0,
         source: '',
         txId: '',
+        afterStateHash: '',
       }
       serializeMakeReceiptReq(stream, obj, false)
       stream.position = 0 // Reset stream position to read from the beginning
@@ -108,6 +111,7 @@ describe('MakeReceiptReq Tests', () => {
         when: Number.MAX_SAFE_INTEGER,
         source: 'source123',
         txId: 'txId123',
+        afterStateHash: 'afterStateHash123',
       }
       serializeMakeReceiptReq(stream, obj, false)
       stream.position = 0 // Reset stream position to read from the beginning
@@ -153,6 +157,7 @@ describe('MakeReceiptReq Tests', () => {
         when: 1234567890,
         source: 'source123',
         txId: 'txId123',
+        afterStateHash: 'afterStateHash123',
       }
       stream.writeUInt8(1) // Version
       stream.writeString(obj.sign.owner)
@@ -180,6 +185,7 @@ describe('MakeReceiptReq Tests', () => {
         when: 0,
         source: '',
         txId: '',
+        afterStateHash: '',
       }
       stream.writeUInt8(1) // Version
       stream.writeString(obj.sign.owner)
@@ -207,6 +213,7 @@ describe('MakeReceiptReq Tests', () => {
         when: Number.MAX_SAFE_INTEGER,
         source: 'source123',
         txId: 'txId123',
+        afterStateHash: 'afterStateHash123',
       }
       stream.writeUInt8(1) // Version
       stream.writeString(obj.sign.owner)


### PR DESCRIPTION
Summary :

On the Shardus core side, we just introduce the afterStateHash in the signed global Tx receipt. 

Context : https://github.com/shardeum/shardeum/pull/359