### PR TITLE
SHARD-2063: Limit accounts in binary_get_account_data_with_queue_hints request

### DIFF
--- a/src/state-manager/index.ts
+++ b/src/state-manager/index.ts
@@ -2097,6 +2097,11 @@ class StateManager {
             return respond(BadRequest(`${route} invalid request`), serializeResponseError)
           }
           const req = deserializeGetAccountDataWithQueueHintsReq(requestStream)
+          const MAX_ACCOUNTS = this.config.stateManager.accountBucketSize
+          if (req.accountIds.length > MAX_ACCOUNTS) {
+            nestedCountersInstance.countEvent('internal', `${route}-too_many_accounts`)
+            return respond(BadRequest(`${route} too many accounts requested`), serializeResponseError)
+          }
           if (utils.isValidShardusAddress(req.accountIds) === false) {
             nestedCountersInstance.countEvent('internal', `${route}-invalid_account_ids`)
             return respond(BadRequest(`${route} invalid account_ids`), serializeResponseError)


### PR DESCRIPTION
### **PR Type**
enhancement, error handling


___

### **Description**
- Limit the number of accounts in requests to a configurable maximum.

- Add error handling for requests exceeding the account limit.

- Track events for invalid and excessive account requests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add account limit and error handling in request processing</code></dd></summary>
<hr>

src/state-manager/index.ts

<li>Introduced a maximum account limit for requests.<br> <li> Added error handling for requests exceeding the limit.<br> <li> Logged events for excessive account requests.


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/443/files#diff-5d499f2b96465a30e026b118eaafa8186196b113886b3e322274014af13ad806">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>