### PR TITLE
SHARD-2099: add limits to `binary_repair_oos_accounts`

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -294,6 +294,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     patcherMaxHashesPerRequest: 300,
     patcherMaxLeafHashesPerRequest: 300,
     patcherMaxChildHashResponses: 2000,
+    patcherRepairByReceiptPerUpdate: 100,
     maxDataSyncRestarts: 5,
     maxTrackerRestarts: 5,
     syncWithAccountOffset: true,

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -1238,6 +1238,8 @@ export interface ServerConfiguration {
     patcherMaxLeafHashesPerRequest: number
     /** max number of child hashes that we can respond with */
     patcherMaxChildHashResponses: number
+    /** max number of requests for account data that execute any given cycle when receiving a repair request */
+    patcherRepairByReceiptPerUpdate: number
     /** max number of sync restarts allowed due to thrown exceptions before we go apop */
     maxDataSyncRestarts: number
     /** max number of sync restarts allowed due to thrown exceptions for each tracker instance */

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -510,6 +510,11 @@ class AccountPatcher {
           }
 
           let [latestCycle] = Context.p2p.getLatestCycles(1)
+          if (!latestCycle) {
+            this.mainLogger.error('repair_oos_accounts: no latest cycle')
+            return
+          }
+
           if (this.repairRequestsMadeThisCycle.cycle !== latestCycle.counter) {
             this.repairRequestsMadeThisCycle.cycle = latestCycle.counter
             this.repairRequestsMadeThisCycle.numRequests = 0

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -187,6 +187,7 @@ class AccountPatcher {
 
   nonStoredRanges: { low: string; high: string }[]
   radixIsStored: Map<string, boolean>
+  repairRequestsMadeThisCycle: { cycle: number; numRequests: number } = { cycle: -1, numRequests: 0 }
 
   lastRepairInfo: unknown
 
@@ -508,25 +509,12 @@ class AccountPatcher {
             return
           }
 
-          // Gather unique accounts
-          const uniqueAccounts = new Set<string>()
-          for (const { accountID } of payload.repairInstructions) {
-            uniqueAccounts.add(accountID)
+          let [latestCycle] = Context.p2p.getLatestCycles(1)
+          if (this.repairRequestsMadeThisCycle.cycle !== latestCycle.counter) {
+            this.repairRequestsMadeThisCycle.cycle = latestCycle.counter
+            this.repairRequestsMadeThisCycle.numRequests = 0
           }
 
-          // Build the storageGroupMap AND keep track of total node queries in a single pass
-          const storageGroupMap = new Map<string, Node[]>()
-          let totalPotentialQueries = 0
-          for (const accountId of uniqueAccounts) {
-            const nodes = this.stateManager.transactionQueue.getStorageGroupForAccount(accountId)
-            storageGroupMap.set(accountId, nodes)
-
-            totalPotentialQueries += nodes.length
-            if (totalPotentialQueries > this.config.stateManager.patcherAccountsPerUpdate) {
-              /* prettier-ignore */ this.mainLogger.warn(`repair_oos_accounts: would query ${totalPotentialQueries} nodes total, above max. Rejecting request.`)
-              return
-            }
-          }
           // verifyPayload(AJVSchemaEnum.RepairOOSAccountsReq', payload)
           for (const repairInstruction of payload.repairInstructions) {
             const { accountID, txId, hash, accountData, targetNodeId, signedReceipt } = repairInstruction
@@ -540,10 +528,9 @@ class AccountPatcher {
               continue
             }
 
-            // Quick lookup in our precomputed map
-            const storageNodes = storageGroupMap.get(accountID) ?? []
-            // Check if node is in the account's storage group
-            const isInStorageGroup = storageNodes.some((node) => node.id === Self.id)
+            // check if we cover this accountId
+            const storageNodes = this.stateManager.transactionQueue.getStorageGroupForAccount(accountID)
+            const isInStorageGroup = storageNodes.map((node) => node.id).includes(Self.id)
             if (!isInStorageGroup) {
               nestedCountersInstance.countEvent(
                 'accountPatcher',
@@ -603,6 +590,18 @@ class AccountPatcher {
               )
             }
 
+            if (
+                this.repairRequestsMadeThisCycle.numRequests + storageNodes.length >
+                this.config.stateManager.patcherRepairByReceiptPerUpdate
+            ) {
+              nestedCountersInstance.countEvent(
+                'accountPatcher',
+                `binary/repair_oos_accounts: too many repair requests this cycle`
+              )
+              this.mainLogger.warn(`binary/repair_oos_accounts: too many repair requests this cycle (${latestCycle.counter})`)
+              return
+            }
+
             // make sure tx hasn't been altered by robust querying for the proposal using request txid and timestamp
             const txReceipt = await robustQuery(storageNodes, queryFn)
             if (txReceipt.isRobustResult === false) {
@@ -612,6 +611,7 @@ class AccountPatcher {
               )
               continue
             }
+            this.repairRequestsMadeThisCycle.numRequests += storageNodes.length
 
             if (
               txReceipt.topResult.success !== true ||

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -504,8 +504,36 @@ class AccountPatcher {
           }
           // (Optional) Check verification data in the header
           const payload = deserializeRepairOOSAccountsReq(requestStream)
+          if (!payload?.repairInstructions) {
+            return
+          }
+
+          if (payload.repairInstructions.length > this.config.stateManager.patcherAccountsPerRequest) {
+            /* prettier-ignore */ this.mainLogger.warn(`repair_oos_accounts: too many repair instructions (${payload.repairInstructions.length}).`)
+            return
+          }
+
+          // Gather unique accounts
+          const uniqueAccounts = new Set<string>()
+          for (const { accountID } of payload.repairInstructions) {
+            uniqueAccounts.add(accountID)
+          }
+
+          // Build the storageGroupMap AND keep track of total node queries in a single pass
+          const storageGroupMap = new Map<string, Node[]>()
+          let totalPotentialQueries = 0
+          for (const accountId of uniqueAccounts) {
+            const nodes = this.stateManager.transactionQueue.getStorageGroupForAccount(accountId)
+            storageGroupMap.set(accountId, nodes)
+
+            totalPotentialQueries += nodes.length
+            if (totalPotentialQueries > this.config.stateManager.patcherAccountsPerUpdate) {
+              /* prettier-ignore */ this.mainLogger.warn(`repair_oos_accounts: would query ${totalPotentialQueries} nodes total, above max. Rejecting request.`)
+              return
+            }
+          }
           // verifyPayload(AJVSchemaEnum.RepairOOSAccountsReq', payload)
-          for (const repairInstruction of payload?.repairInstructions) {
+          for (const repairInstruction of payload.repairInstructions) {
             const { accountID, txId, hash, accountData, targetNodeId, signedReceipt } = repairInstruction
 
             // check if we are the target node
@@ -517,9 +545,10 @@ class AccountPatcher {
               continue
             }
 
-            // check if we cover this accountId
-            const storageNodes = this.stateManager.transactionQueue.getStorageGroupForAccount(accountID)
-            const isInStorageGroup = storageNodes.map((node) => node.id).includes(Self.id)
+            // Quick lookup in our precomputed map
+            const storageNodes = storageGroupMap.get(accountID) ?? []
+            // Check if node is in the account's storage group
+            const isInStorageGroup = storageNodes.some((node) => node.id === Self.id)
             if (!isInStorageGroup) {
               nestedCountersInstance.countEvent(
                 'accountPatcher',

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -508,11 +508,6 @@ class AccountPatcher {
             return
           }
 
-          if (payload.repairInstructions.length > this.config.stateManager.patcherAccountsPerRequest) {
-            /* prettier-ignore */ this.mainLogger.warn(`repair_oos_accounts: too many repair instructions (${payload.repairInstructions.length}).`)
-            return
-          }
-
           // Gather unique accounts
           const uniqueAccounts = new Set<string>()
           for (const { accountID } of payload.repairInstructions) {

--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -596,8 +596,8 @@ class AccountPatcher {
             }
 
             if (
-                this.repairRequestsMadeThisCycle.numRequests + storageNodes.length >
-                this.config.stateManager.patcherRepairByReceiptPerUpdate
+              this.repairRequestsMadeThisCycle.numRequests + 1 >
+              this.config.stateManager.patcherRepairByReceiptPerUpdate
             ) {
               nestedCountersInstance.countEvent(
                 'accountPatcher',
@@ -616,7 +616,7 @@ class AccountPatcher {
               )
               continue
             }
-            this.repairRequestsMadeThisCycle.numRequests += storageNodes.length
+            this.repairRequestsMadeThisCycle.numRequests++
 
             if (
               txReceipt.topResult.success !== true ||


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Add limits to repair instructions and node queries.

- Implement unique account gathering for efficiency.

- Precompute storage group map for quick lookups.

- Warn and reject requests exceeding configured limits.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountPatcher.ts</strong><dd><code>Add limits and optimizations to account repair process</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/state-manager/AccountPatcher.ts

<li>Added checks for repair instruction limits.<br> <li> Implemented unique account gathering using a Set.<br> <li> Precomputed storage group map for efficiency.<br> <li> Added warnings for exceeding node query limits.


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/449/files#diff-99f440a28661dbec3401c508820c3c594bd951a41761d50255ec8a840ab897fb">+33/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>