### PR TITLE
Shard 2195

### DIFF
--- a/src/state-manager/AccountPatcher.ts
+++ b/src/state-manager/AccountPatcher.ts
@@ -943,6 +943,12 @@ class AccountPatcher {
         ): void => requestErrorHandler(route, errorType, header, opts)
 
         try {
+          const activeList = NodeList.activeByIdOrder
+          const isActive = activeList.some((node) => node.id === header.sender_id)
+          if (!isActive) {
+            return errorHandler(RequestErrorEnum.InvalidRequest)
+          }
+
           const stream = getStreamWithTypeCheck(payload, TypeIdentifierEnum.cSyncTrieHashesReq)
           if (!stream) {
             return errorHandler(RequestErrorEnum.InvalidRequest)


### PR DESCRIPTION
Updated binary_sync_trie_hashes to check that the payload it received comes from an active node