### PR TITLE
skip activating nodes vote for cycle marker

### DIFF
--- a/src/p2p/Active.ts
+++ b/src/p2p/Active.ts
@@ -71,6 +71,7 @@ let p2pLogger: Logger
 
 let activeRequests: Map<P2P.NodeListTypes.Node['publicKey'], P2P.ActiveTypes.SignedActiveRequest>
 let queuedRequest: P2P.ActiveTypes.ActiveRequest
+export let activated: string[] = []
 export let neverGoActive = false
 
 /** FUNCTIONS */
@@ -100,6 +101,7 @@ export function init() {
 
 export function reset() {
   activeRequests = new Map()
+  activated = []
 }
 
 export function getTxs(): P2P.ActiveTypes.Txs {
@@ -137,7 +139,7 @@ export function updateRecord(
   _prev: P2P.CycleCreatorTypes.CycleRecord
 ) {
   const active = NodeList.activeByIdOrder.length
-  const activated = []
+  activated = []
   const activatedPublicKeys = []
 
   if (NodeList.readyByTimeAndIdOrder.length > 0) {

--- a/src/p2p/CycleCreator.ts
+++ b/src/p2p/CycleCreator.ts
@@ -1163,7 +1163,7 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
 
   //  warn(`improveBestCert: have:${JSON.stringify(have)}`)
   for (const cert of inpCerts) {
-    if (CycleChain.newest.activated.includes(cert.sign.owner)) {
+    if (Active.activated.includes(cert.sign.owner)) {
       continue
     }
     // make sure we don't store more than one cert from the same owner with the same marker
@@ -1189,7 +1189,7 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
     }
   }
   for (const cert of inpCerts) {
-    if (CycleChain.newest.activated.includes(cert.sign.owner)) {
+    if (Active.activated.includes(cert.sign.owner)) {
       continue
     }
     let score = 0

--- a/src/p2p/CycleCreator.ts
+++ b/src/p2p/CycleCreator.ts
@@ -1163,6 +1163,9 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
 
   //  warn(`improveBestCert: have:${JSON.stringify(have)}`)
   for (const cert of inpCerts) {
+    if (CycleChain.newest.activated.includes(cert.sign.owner)) {
+      continue
+    }
     // make sure we don't store more than one cert from the same owner with the same marker
     if (have[cert.sign.owner]) continue
     cert.score = scoreCert(cert, prevMarkerCached)
@@ -1186,6 +1189,9 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
     }
   }
   for (const cert of inpCerts) {
+    if (CycleChain.newest.activated.includes(cert.sign.owner)) {
+      continue
+    }
     let score = 0
     const bcerts = bestCycleCert.get(cert.marker)
     for (const bcert of bcerts) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Skip processing cycle certificates from already activated nodes

- Add checks in both certificate scoring and selection loops

- Prevent duplicate or unnecessary certificate handling

- Improve efficiency and correctness in cycle marker logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CycleCreator.ts</strong><dd><code>Skip certs from activated nodes in cycle certificate processing</code></dd></summary>
<hr>

src/p2p/CycleCreator.ts

<li>Added checks to skip certs from activated nodes in two loops<br> <li> Prevented scoring and selection of certs for already activated owners<br> <li> Improved logic for handling cycle certificates and markers


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/470/files#diff-1ed162b6d992649b34721f34c9a4dc3a660ee72f7414a33bf4b9dde629c5d6d0">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>