### PR TITLE
SHARD-2182 : recent restore fixes

### DIFF
--- a/src/p2p/Active.ts
+++ b/src/p2p/Active.ts
@@ -72,6 +72,8 @@ let p2pLogger: Logger
 let activeRequests: Map<P2P.NodeListTypes.Node['publicKey'], P2P.ActiveTypes.SignedActiveRequest>
 let queuedRequest: P2P.ActiveTypes.ActiveRequest
 export let activated: string[] = []
+export const enableSkipActivatedCert = process.env.enableSkipActivatedCert === 'true' ? true : false
+console.log('[restore-415] enableSkipActivatedCert', enableSkipActivatedCert)
 export let neverGoActive = false
 
 /** FUNCTIONS */

--- a/src/p2p/Active.ts
+++ b/src/p2p/Active.ts
@@ -71,6 +71,7 @@ let p2pLogger: Logger
 
 let activeRequests: Map<P2P.NodeListTypes.Node['publicKey'], P2P.ActiveTypes.SignedActiveRequest>
 let queuedRequest: P2P.ActiveTypes.ActiveRequest
+export let activated: string[] = []
 export let neverGoActive = false
 
 /** FUNCTIONS */
@@ -100,6 +101,7 @@ export function init() {
 
 export function reset() {
   activeRequests = new Map()
+  activated = []
 }
 
 export function getTxs(): P2P.ActiveTypes.Txs {
@@ -137,7 +139,7 @@ export function updateRecord(
   _prev: P2P.CycleCreatorTypes.CycleRecord
 ) {
   const active = NodeList.activeByIdOrder.length
-  const activated = []
+  activated = []
   const activatedPublicKeys = []
 
   if (NodeList.readyByTimeAndIdOrder.length > 0) {

--- a/src/p2p/Archivers.ts
+++ b/src/p2p/Archivers.ts
@@ -859,7 +859,7 @@ export function sendData() {
       cyclesWithMarker.push({
         ...cycleRecords[i],
         marker: computeCycleMarker(cycleRecords[i]),
-        certificates: CycleCreator.getBestCycleCerts(),
+        certificates: CycleCreator.getBestCycleCerts(cycleRecords[i].counter),
       })
     }
     // Update lastSentCycle

--- a/src/p2p/CycleCreator.ts
+++ b/src/p2p/CycleCreator.ts
@@ -132,6 +132,8 @@ let bestCertScore: Map<P2P.CycleCreatorTypes.CycleMarker, number>
 
 const timers = {}
 
+let listOfCycleCerts: Map<number, P2P.CycleCreatorTypes.CycleCert[]> = new Map()
+
 // Keeps track of the last saved record in the DB in order to update it
 let lastSavedData: P2P.CycleCreatorTypes.CycleRecord
 
@@ -698,6 +700,12 @@ async function runQ4() {
     Certified cycle marker: ${Utils.safeStringify(marker)}
     Certified cycle cert: ${Utils.safeStringify(cert)}
   `)
+
+    listOfCycleCerts.set(currentCycle, bestCycleCert.get(bestMarker))
+    // prune listOfCycleCerts to 100 elements
+    if (listOfCycleCerts.size > 100) {
+      listOfCycleCerts.delete(currentCycle - 100)
+    }
   } finally {
     /* prettier-ignore */ if (logFlags.p2pNonFatal) info( `Q4: END: myC:${myC}  C${currentCycle} Q${currentQuarter} Certified cycle record: ${Utils.safeStringify(record.counter)}` )
     // Dont need this any more since we are not doing anything after this
@@ -1163,6 +1171,9 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
 
   //  warn(`improveBestCert: have:${JSON.stringify(have)}`)
   for (const cert of inpCerts) {
+    if (Active.activated.includes(cert.sign.owner)) {
+      continue
+    }
     // make sure we don't store more than one cert from the same owner with the same marker
     if (have[cert.sign.owner]) continue
     cert.score = scoreCert(cert, prevMarkerCached)
@@ -1186,6 +1197,9 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
     }
   }
   for (const cert of inpCerts) {
+    if (Active.activated.includes(cert.sign.owner)) {
+      continue
+    }
     let score = 0
     const bcerts = bestCycleCert.get(cert.marker)
     for (const bcert of bcerts) {
@@ -1382,8 +1396,8 @@ function pruneCycleChain() {
   }
 }
 
-export function getBestCycleCerts() {
-  return bestCycleCert.get(bestMarker) ?? []
+export function getBestCycleCerts(counter: number) {
+  return listOfCycleCerts.get(counter) ?? []
 }
 
 function info(...msg) {

--- a/src/p2p/CycleCreator.ts
+++ b/src/p2p/CycleCreator.ts
@@ -132,7 +132,7 @@ let bestCertScore: Map<P2P.CycleCreatorTypes.CycleMarker, number>
 
 const timers = {}
 
-let listOfCycleCerts: Map<number, P2P.CycleCreatorTypes.CycleCert[]> = new Map()
+let cacheOfCycleCerts: utils.FIFOCache<number, P2P.CycleCreatorTypes.CycleCert[]>
 
 // Keeps track of the last saved record in the DB in order to update it
 let lastSavedData: P2P.CycleCreatorTypes.CycleRecord
@@ -243,6 +243,8 @@ export function init() {
   // Get a handle to write to p2p.log
   p2pLogger = logger.getLogger('p2p')
   cycleLogger = logger.getLogger('cycle')
+
+  cacheOfCycleCerts = new utils.FIFOCache<number, P2P.CycleCreatorTypes.CycleCert[]>(100)
 
   for (const submodule of submodules) {
     if (submodule.init) submodule.init()
@@ -701,11 +703,7 @@ async function runQ4() {
     Certified cycle cert: ${Utils.safeStringify(cert)}
   `)
 
-    listOfCycleCerts.set(currentCycle, bestCycleCert.get(bestMarker))
-    // prune listOfCycleCerts to 100 elements
-    if (listOfCycleCerts.size > 100) {
-      listOfCycleCerts.delete(currentCycle - 100)
-    }
+    cacheOfCycleCerts.set(currentCycle, bestCycleCert.get(bestMarker))
   } finally {
     /* prettier-ignore */ if (logFlags.p2pNonFatal) info( `Q4: END: myC:${myC}  C${currentCycle} Q${currentQuarter} Certified cycle record: ${Utils.safeStringify(record.counter)}` )
     // Dont need this any more since we are not doing anything after this
@@ -1397,7 +1395,7 @@ function pruneCycleChain() {
 }
 
 export function getBestCycleCerts(counter: number) {
-  return listOfCycleCerts.get(counter) ?? []
+  return cacheOfCycleCerts.get(counter) ?? []
 }
 
 function info(...msg) {

--- a/src/p2p/CycleCreator.ts
+++ b/src/p2p/CycleCreator.ts
@@ -1171,7 +1171,7 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
 
   //  warn(`improveBestCert: have:${JSON.stringify(have)}`)
   for (const cert of inpCerts) {
-    if (Active.activated.includes(cert.sign.owner)) {
+    if (Active.enableSkipActivatedCert && Active.activated.includes(cert.sign.owner)) {
       continue
     }
     // make sure we don't store more than one cert from the same owner with the same marker
@@ -1197,7 +1197,7 @@ function improveBestCert(inpCerts: P2P.CycleCreatorTypes.CycleCert[], inpRecord)
     }
   }
   for (const cert of inpCerts) {
-    if (Active.activated.includes(cert.sign.owner)) {
+    if (Active.enableSkipActivatedCert && Active.activated.includes(cert.sign.owner)) {
       continue
     }
     let score = 0

--- a/test/unit/src/network/debugMiddleware.test.ts
+++ b/test/unit/src/network/debugMiddleware.test.ts
@@ -74,8 +74,8 @@ jest.mock('@shardeum-foundation/lib-types', () => ({
     safeJsonParse: jest.fn(),
   },
   StateManager: {
-    StateManagerTypes: {}
-  }
+    StateManagerTypes: {},
+  },
 }))
 
 jest.mock('../../../../src/network', () => ({
@@ -384,11 +384,11 @@ describe('debugMiddleware', () => {
       mockSafeStringify.mockReturnValue('{"stringified":"payload"}')
       mockVerify.mockReturnValue(true)
       mockEnsureKeySecurity.mockReturnValue(false)
-      
+
       // Mock Date.now() to return a fixed value
       const realDateNow = Date.now
       Date.now = jest.fn(() => currentTime)
-      
+
       // Set lastCounter to a value less than validCounter to ensure the counter check passes
       const lastCounterModule = require('../../../../src/network/debugMiddleware')
       lastCounterModule.lastCounter = currentTime - 1000


### PR DESCRIPTION
Resolves issue where nodes were forwarding the wrong best cycle markers when more than one cycle had to be forwarded.
Optional edge case fix to limit recently activated nodes from sending cycle data.

