### PR TITLE
SHARD-2310: add kill node flag to core flags

### DIFF
--- a/src/shardus/coreFlags.ts
+++ b/src/shardus/coreFlags.ts
@@ -6,6 +6,10 @@ export interface CoreFlags {
    * Indicates whether the contract storage key silo feature is enabled.
    */
   contractStorageKeySilo: boolean
+  /**
+   * Indicates whether the kill node flag is enabled.
+   */
+  killNodeFlag: boolean
 }
 
 /**
@@ -16,4 +20,8 @@ export const CoreFlags: CoreFlags = {
    * Enables the contract storage key silo feature by default.
    */
   contractStorageKeySilo: true,
+  /**
+   * Enables the kill node flag by default.
+   */
+  killNodeFlag: false,
 }

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -3529,7 +3529,8 @@ class Shardus extends EventEmitter {
       if (key === 'killNodeFlag') {
         if (value) {
           console.error('Killing node abruptly...')
-          process.kill(process.pid, 'SIGKILL')
+          // process.kill(process.pid, 'SIGKILL') //pm2 restarts the node
+          Self.emitter.emit('invoke-exit', 'killSelf', getCallstack(), 'I have been killed ungracefully, not restarting.')
         }
       }
     } catch (e) {

--- a/src/shardus/index.ts
+++ b/src/shardus/index.ts
@@ -3526,6 +3526,12 @@ class Shardus extends EventEmitter {
       // Update the core flag with the new value
       CoreFlags[key] = value
       console.log(`Shardus-core flag ${key} is set to ${value}`)
+      if (key === 'killNodeFlag') {
+        if (value) {
+          console.error('Killing node abruptly...')
+          process.kill(process.pid, 'SIGKILL')
+        }
+      }
     } catch (e) {
       // Log any unexpected errors
       console.log(`Error: unexpected behaviour in updateCoreFlag`, e)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `killNodeFlag` to `CoreFlags` interface and defaults.

- Implemented logic to kill node when `killNodeFlag` is set.

- Updated documentation/comments for new flag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coreFlags.ts</strong><dd><code>Add killNodeFlag to CoreFlags interface and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardus/coreFlags.ts

<li>Introduced <code>killNodeFlag</code> to <code>CoreFlags</code> interface.<br> <li> Set default value for <code>killNodeFlag</code> to false.<br> <li> Added documentation for the new flag.


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/478/files#diff-1bd141b288dfd485e4ed849464336021286cf590c1ba2e114a471efeb2a9ae49">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement node termination on killNodeFlag activation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardus/index.ts

<li>Added logic to terminate process if <code>killNodeFlag</code> is set to true.<br> <li> Logged error message before abrupt termination.


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/478/files#diff-7688b1f28fe4334909528fe3b035aed676fd45c47388157780feecd1df614986">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>