### PR TITLE
fix: pass by reference issue

### DIFF
--- a/src/state-manager/TransactionConsensus.ts
+++ b/src/state-manager/TransactionConsensus.ts
@@ -1167,7 +1167,7 @@ class TransactionConsenus {
           return
         }
 
-        queueEntry.signedReceipt = payload
+        queueEntry.signedReceipt = { ...payload }
         payload.txGroupCycle = queueEntry.txGroupCycle
         Comms.sendGossip(
           'poqo-receipt-gossip',


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes pass-by-reference issue when assigning `signedReceipt`

- Ensures `queueEntry.signedReceipt` is a shallow copy of payload

- Prevents unintended side effects from object mutation

- Improves data integrity in transaction consensus logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransactionConsensus.ts</strong><dd><code>Use shallow copy for signedReceipt to avoid reference issues</code></dd></summary>
<hr>

src/state-manager/TransactionConsensus.ts

<li>Replaces direct assignment with shallow copy for <br><code>queueEntry.signedReceipt</code><br> <li> Prevents mutation of original <code>payload</code> object<br> <li> Addresses potential data integrity issues in receipt processing


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/487/files#diff-f0931741dffffcfe7a46daaa81a01eeaa9b1e2f108657011c70f4562ed530a5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>