### PR TITLE
feat : adds logging to archiver receipt retrieval

### DIFF
--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -7648,18 +7648,13 @@ class TransactionQueue {
     // this.updateTxState(queueEntry, 'almostExpired')
     queueEntry.almostExpired = true
 
-    /* prettier-ignore */
-    nestedCountersInstance.countEvent("txAlmostExpired", `tx: ${this.app.getSimpleTxDebugValue(queueEntry.acceptedTx?.data)}`)
+    /* prettier-ignore */ nestedCountersInstance.countEvent("txAlmostExpired", `tx: ${this.app.getSimpleTxDebugValue(queueEntry.acceptedTx?.data)}`)
   }
 
   async getArchiverReceiptFromQueueEntry(queueEntry: QueueEntry): Promise<ArchiverReceipt> {
     if (!queueEntry.preApplyTXResult || !queueEntry.preApplyTXResult.applyResponse) {
-      if (logFlags.verbose)
-        console.log('getArchiverReceiptFromQueueEntry : no preApplyTXResult or applyResponse, returning null receipt')
-      nestedCountersInstance.countEvent(
-        'stateManager',
-        'getArchiverReceiptFromQueueEntry no preApplyTXResult or applyResponse'
-      )
+      /* prettier-ignore */ if (logFlags.verbose) console.log('getArchiverReceiptFromQueueEntry : no preApplyTXResult or applyResponse, returning null receipt')
+      /* prettier-ignore */ nestedCountersInstance.countEvent('stateManager', 'getArchiverReceiptFromQueueEntry no preApplyTXResult or applyResponse')
       return null as ArchiverReceipt
     }
 
@@ -7670,52 +7665,20 @@ class TransactionQueue {
     let signedReceipt = null as SignedReceipt | P2PTypes.GlobalAccountsTypes.GlobalTxReceipt
     if (globalModification) {
       signedReceipt = getGlobalTxReceipt(queueEntry.acceptedTx.txId) as P2PTypes.GlobalAccountsTypes.GlobalTxReceipt
-
-      if (logFlags.important_as_error) {
-        console.log('getArchiverReceiptFromQueueEntry : globalModification signedReceipt txid', txId)
-        console.log(
-          'getArchiverReceiptFromQueueEntry : globalModification signedReceipt signs',
-          txId,
-          Utils.safeStringify(signedReceipt.signs)
-        )
-        console.log(
-          'getArchiverReceiptFromQueueEntry : globalModification signedReceipt tx',
-          txId,
-          Utils.safeStringify(signedReceipt.tx)
-        )
-      }
+      /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : globalModification signedReceipt txid', txId)
+      /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : globalModification signedReceipt signs', txId, Utils.safeStringify(signedReceipt.signs))
+      /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : globalModification signedReceipt tx', txId, Utils.safeStringify(signedReceipt.tx))
     } else {
       signedReceipt = this.stateManager.getSignedReceipt(queueEntry) as SignedReceipt
-
-      if (logFlags.important_as_error) {
-        console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt txid', txId)
-        console.log(
-          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposal',
-          txId,
-          Utils.safeStringify(signedReceipt.proposal)
-        )
-        console.log(
-          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposalHash',
-          txId,
-          Utils.safeStringify(signedReceipt.proposalHash)
-        )
-        console.log(
-          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt signaturePack',
-          txId,
-          Utils.safeStringify(signedReceipt.signaturePack)
-        )
-        console.log(
-          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt voteOffsets',
-          txId,
-          Utils.safeStringify(signedReceipt.voteOffsets)
-        )
-      }
+        /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt txid', txId)
+        /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposal', txId, Utils.safeStringify(signedReceipt.proposal))
+        /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposalHash', txId, Utils.safeStringify(signedReceipt.proposalHash))
+        /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt signaturePack', txId, Utils.safeStringify(signedReceipt.signaturePack))
+        /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt voteOffsets', txId, Utils.safeStringify(signedReceipt.voteOffsets))
     }
     if (!signedReceipt) {
-      nestedCountersInstance.countEvent('stateManager', 'getArchiverReceiptFromQueueEntry no signedReceipt')
-      console.log(
-        `getArchiverReceiptFromQueueEntry: signedReceipt is null for txId: ${txId} timestamp: ${timestamp} globalModification: ${globalModification}`
-      )
+      /* prettier-ignore */ nestedCountersInstance.countEvent('stateManager', 'getArchiverReceiptFromQueueEntry no signedReceipt')
+      /* prettier-ignore */ if (logFlags.important_as_error) console.log(`getArchiverReceiptFromQueueEntry: signedReceipt is null for txId: ${txId} timestamp: ${timestamp} globalModification: ${globalModification}`)
       return null as ArchiverReceipt
     }
 
@@ -7899,14 +7862,8 @@ class TransactionQueue {
       cycle: queueEntry.txGroupCycle,
       globalModification,
     }
-    if (logFlags.important_as_error) {
-      console.log('getArchiverReceiptFromQueueEntry : archiverReceipt', txId, Utils.safeStringify(archiverReceipt))
-      console.log(
-        'getArchiverReceiptFromQueueEntry : originalTxData object',
-        txId,
-        Utils.safeStringify(archiverReceipt.tx.originalTxData)
-      )
-    }
+    /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : archiverReceipt', txId, Utils.safeStringify(archiverReceipt))
+    /* prettier-ignore */ if (logFlags.important_as_error) console.log('getArchiverReceiptFromQueueEntry : originalTxData object', txId, Utils.safeStringify(archiverReceipt.tx.originalTxData))
 
     return archiverReceipt
   }

--- a/src/state-manager/TransactionQueue.ts
+++ b/src/state-manager/TransactionQueue.ts
@@ -7653,7 +7653,15 @@ class TransactionQueue {
   }
 
   async getArchiverReceiptFromQueueEntry(queueEntry: QueueEntry): Promise<ArchiverReceipt> {
-    if (!queueEntry.preApplyTXResult || !queueEntry.preApplyTXResult.applyResponse) return null as ArchiverReceipt
+    if (!queueEntry.preApplyTXResult || !queueEntry.preApplyTXResult.applyResponse) {
+      if (logFlags.verbose)
+        console.log('getArchiverReceiptFromQueueEntry : no preApplyTXResult or applyResponse, returning null receipt')
+      nestedCountersInstance.countEvent(
+        'stateManager',
+        'getArchiverReceiptFromQueueEntry no preApplyTXResult or applyResponse'
+      )
+      return null as ArchiverReceipt
+    }
 
     const txId = queueEntry.acceptedTx.txId
     const timestamp = queueEntry.acceptedTx.timestamp
@@ -7662,8 +7670,46 @@ class TransactionQueue {
     let signedReceipt = null as SignedReceipt | P2PTypes.GlobalAccountsTypes.GlobalTxReceipt
     if (globalModification) {
       signedReceipt = getGlobalTxReceipt(queueEntry.acceptedTx.txId) as P2PTypes.GlobalAccountsTypes.GlobalTxReceipt
+
+      if (logFlags.important_as_error) {
+        console.log('getArchiverReceiptFromQueueEntry : globalModification signedReceipt txid', txId)
+        console.log(
+          'getArchiverReceiptFromQueueEntry : globalModification signedReceipt signs',
+          txId,
+          Utils.safeStringify(signedReceipt.signs)
+        )
+        console.log(
+          'getArchiverReceiptFromQueueEntry : globalModification signedReceipt tx',
+          txId,
+          Utils.safeStringify(signedReceipt.tx)
+        )
+      }
     } else {
       signedReceipt = this.stateManager.getSignedReceipt(queueEntry) as SignedReceipt
+
+      if (logFlags.important_as_error) {
+        console.log('getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt txid', txId)
+        console.log(
+          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposal',
+          txId,
+          Utils.safeStringify(signedReceipt.proposal)
+        )
+        console.log(
+          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt proposalHash',
+          txId,
+          Utils.safeStringify(signedReceipt.proposalHash)
+        )
+        console.log(
+          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt signaturePack',
+          txId,
+          Utils.safeStringify(signedReceipt.signaturePack)
+        )
+        console.log(
+          'getArchiverReceiptFromQueueEntry : nonGlobal signedReceipt voteOffsets',
+          txId,
+          Utils.safeStringify(signedReceipt.voteOffsets)
+        )
+      }
     }
     if (!signedReceipt) {
       nestedCountersInstance.countEvent('stateManager', 'getArchiverReceiptFromQueueEntry no signedReceipt')
@@ -7853,6 +7899,15 @@ class TransactionQueue {
       cycle: queueEntry.txGroupCycle,
       globalModification,
     }
+    if (logFlags.important_as_error) {
+      console.log('getArchiverReceiptFromQueueEntry : archiverReceipt', txId, Utils.safeStringify(archiverReceipt))
+      console.log(
+        'getArchiverReceiptFromQueueEntry : originalTxData object',
+        txId,
+        Utils.safeStringify(archiverReceipt.tx.originalTxData)
+      )
+    }
+
     return archiverReceipt
   }
 


### PR DESCRIPTION
### **User description**
Adds verbose logging and counters to the
`getArchiverReceiptFromQueueEntry` function.

This provides more insight into when and why receipts
cannot be retrieved, particularly for global and non-global
transactions. Improves debuggability.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds verbose and error-level logging to `getArchiverReceiptFromQueueEntry`

- Introduces event counters for missing receipt scenarios

- Logs detailed receipt data for global and non-global transactions

- Improves debuggability of archiver receipt retrieval process


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransactionQueue.ts</strong><dd><code>Add detailed logging and counters to archiver receipt retrieval</code></dd></summary>
<hr>

src/state-manager/TransactionQueue.ts

<li>Adds verbose logging when <code>preApplyTXResult</code> or <code>applyResponse</code> is missing<br> <li> Introduces event counters for missing receipt conditions<br> <li> Logs detailed receipt data for both global and non-global transactions<br> <li> Adds logging for the final constructed <code>archiverReceipt</code>


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/488/files#diff-be30d4f58780a88420b4edeaf195d6e5e41e11c8de44591839e0eb8e8d0c266f">+55/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>