### PR TITLE
Enable autoscaled join limit

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -64,6 +64,7 @@ const SERVER_CONFIG: StrictServerConfiguration = {
     seedNodeOffset: 4,
     nodeExpiryAge: 30,
     maxJoinedPerCycle: 1,
+    maxJoinLimit: 1,
     maxSyncingPerCycle: 5,
     syncBoostEnabled: true,
     maxSyncTimeFloor: 1200,

--- a/src/p2p/CycleAutoScale.ts
+++ b/src/p2p/CycleAutoScale.ts
@@ -31,6 +31,8 @@ export let scalingRequestsCollector: Map<
 >
 export let desiredCount: number
 export let targetCount: number
+/** max nodes allowed to join per cycle; autoscaling modules may adjust */
+export let joinLimit: number
 
 reset()
 
@@ -72,6 +74,7 @@ const routes = {
 export function init() {
   p2pLogger = logger.getLogger('p2p')
   desiredCount = config.p2p.minNodes
+  joinLimit = config?.p2p?.maxJoinLimit ?? config?.p2p?.maxJoinedPerCycle ?? 1
 
   for (const [name, handler] of Object.entries(routes.gossip)) {
     Comms.registerGossipHandler(name, handler)
@@ -84,6 +87,7 @@ export function reset() {
   scalingRequestsCollector = new Map()
   requestedScalingType = null
   approvedScalingType = null
+  joinLimit = config?.p2p?.maxJoinLimit ?? config?.p2p?.maxJoinedPerCycle ?? 1
 }
 
 export function getDesiredCount(): number {
@@ -94,6 +98,14 @@ export function getDesiredCount(): number {
   } else {
     return desiredCount
   }
+}
+
+export function getJoinLimit(): number {
+  return joinLimit
+}
+
+export function setJoinLimit(limit: number): void {
+  joinLimit = limit
 }
 
 function createScaleRequest(scaleType): P2P.CycleAutoScaleTypes.SignedScaleRequest {
@@ -449,6 +461,7 @@ export function configUpdated() {
   //   //we may still want this, but need some special testing to be sure
   //   //requestNetworkDownsize()
   // }
+  joinLimit = config?.p2p?.maxJoinLimit ?? config?.p2p?.maxJoinedPerCycle ?? 1
 }
 
 export function queueRequest(request) {}

--- a/src/p2p/Join/index.ts
+++ b/src/p2p/Join/index.ts
@@ -16,6 +16,7 @@ import { isBogonIP, isInvalidIP, isIPv6 } from '../../utils/functions/checkIP'
 import { nestedCountersInstance } from '../../utils/nestedCounters'
 import { Logger } from 'log4js'
 import { calculateToAcceptV2 } from '../ModeSystemFuncs'
+import { getJoinLimit } from '../CycleAutoScale'
 import { routes } from './routes'
 import {
   debugDumpJoinRequestList,
@@ -120,7 +121,7 @@ export function getNodeRequestingJoin(): P2P.P2PTypes.P2PNode[] {
 export function calculateToAccept(): number {
   const desired = CycleChain.newest.desired
   const active = CycleChain.newest.active
-  let maxJoin = config.p2p.maxJoinedPerCycle // [TODO] allow autoscaling to change this
+  let maxJoin = getJoinLimit()
   const syncing = NodeList.byJoinOrder.length - active
   const expired = CycleChain.newest.expired
 

--- a/src/shardus/shardus-types.ts
+++ b/src/shardus/shardus-types.ts
@@ -756,6 +756,8 @@ export interface ServerConfiguration {
 
     /** The maxJoinedPerCycle parameter is an Integer specifying the maximum number of nodes that can join the syncing phase each cycle. */
     maxJoinedPerCycle?: number
+    /** Autoscaled limit for nodes that can join each cycle */
+    maxJoinLimit?: number
     /** The maxSyncingPerCycle parameter is an Integer specifying the maximum number of nodes that can be in the syncing phase each cycle. */
     maxSyncingPerCycle?: number
     /** allow syncing more nodes in a small network. only works well if we are not loading a lot of data */

--- a/test/unit/src/p2p/CycleAutoScale.test.ts
+++ b/test/unit/src/p2p/CycleAutoScale.test.ts
@@ -1,0 +1,15 @@
+jest.mock('../../../../src/logger', () => ({
+  getLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), mainLog_debug: jest.fn(), combine: jest.fn() }),
+  logFlags: {},
+}))
+
+import { setJoinLimit, getJoinLimit } from '../../../../src/p2p/CycleAutoScale'
+
+describe('CycleAutoScale join limit', () => {
+  it('should update join limit', () => {
+    setJoinLimit(7)
+    expect(getJoinLimit()).toBe(7)
+    setJoinLimit(2)
+    expect(getJoinLimit()).toBe(2)
+  })
+})


### PR DESCRIPTION
### **User description**
## Summary
- scale max nodes joining per cycle through CycleAutoScale
- initialize and reset autoscaled join limit
- use `getJoinLimit` in join calculations
- add unit test for the join limit helpers

## Testing
- `npm test`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduce autoscaled join limit with `maxJoinLimit` config option

- Add `getJoinLimit` and `setJoinLimit` helpers in `CycleAutoScale`

- Update join calculations to use autoscaled join limit

- Add unit test for join limit helper functions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.ts</strong><dd><code>Add and initialize `maxJoinLimit` in server config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/server.ts

<li>Add <code>maxJoinLimit</code> to server configuration<br> <li> Set initial value for autoscaled join limit


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/495/files#diff-05a02685a2bd9e313c6773e0f8960f5b444de56822d978a8aef55ecb986aa200">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CycleAutoScale.ts</strong><dd><code>Implement autoscaled join limit logic and helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/p2p/CycleAutoScale.ts

<li>Add <code>joinLimit</code> variable for autoscaled join limit<br> <li> Implement <code>getJoinLimit</code> and <code>setJoinLimit</code> functions<br> <li> Initialize and reset <code>joinLimit</code> in lifecycle functions<br> <li> Update <code>configUpdated</code> to refresh <code>joinLimit</code>


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/495/files#diff-e043fb7c4ce4b61d223458fe7626f7f3960528572d3e5404b921fd0cac7d95fb">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Use autoscaled join limit in join calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/p2p/Join/index.ts

- Use `getJoinLimit` instead of static config for join calculation


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/495/files#diff-219e0420b669274e5220d059e656a37382361210a5e30ce4379a8a64cddd9a2e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shardus-types.ts</strong><dd><code>Add `maxJoinLimit` to server configuration types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shardus/shardus-types.ts

<li>Add <code>maxJoinLimit</code> to <code>ServerConfiguration</code> interface<br> <li> Document autoscaled join limit option


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/495/files#diff-b2d038ee26dfe8de47db34761ceca12d86519e89a0aa69ee9521caec885a8ada">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CycleAutoScale.test.ts</strong><dd><code>Add tests for join limit helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/p2p/CycleAutoScale.test.ts

<li>Add unit tests for <code>setJoinLimit</code> and <code>getJoinLimit</code><br> <li> Mock logger for test isolation


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/495/files#diff-690cf936e9c968fba84db558b2d163af78286c2a34050d862df87c01bd6e790b">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>