### PR TITLE
Add throttling counters

### DIFF
--- a/src/rate-limiting/index.ts
+++ b/src/rate-limiting/index.ts
@@ -86,7 +86,11 @@ class RateLimiting {
           queueLoad.executeQueueLength
         }`
       )
-      nestedCountersInstance.countEvent('loadRelated', 'txRejected:' + loadType)
+      if (Context.shardus && typeof Context.shardus.monitorEvent === 'function') {
+        Context.shardus.monitorEvent('loadRelated', 'txRejected:' + loadType, 1, '')
+      } else {
+        nestedCountersInstance.countEvent('loadRelated', 'txRejected:' + loadType)
+      }
     }
 
     return overloaded

--- a/test/unit/src/rate-limiting/index.test.ts
+++ b/test/unit/src/rate-limiting/index.test.ts
@@ -1,0 +1,56 @@
+import RateLimiting from '../../../../src/rate-limiting'
+import * as Context from '../../../../src/p2p/Context'
+
+jest.mock('../../../../src/utils/nestedCounters', () => ({
+  nestedCountersInstance: { countEvent: jest.fn() },
+}))
+
+jest.mock('../../../../src/logger', () => ({
+  logFlags: { seqdiagram: false },
+}))
+
+jest.mock('../../../../src/network', () => ({
+  shardusGetTime: jest.fn().mockReturnValue(0),
+}))
+
+jest.mock('../../../../src/p2p/NodeList', () => ({
+  activeIdToPartition: new Map().set('self', '0'),
+}))
+
+jest.mock('../../../../src/p2p/Self', () => ({ id: 'self' }))
+
+const monitorEvent = jest.fn()
+const getCurrentNodeLoad = jest.fn()
+const getQueueLoad = jest.fn()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(Context as any).shardus = {
+    monitorEvent,
+    loadDetection: { getCurrentNodeLoad, getQueueLoad },
+  }
+})
+
+describe('RateLimiting.isOverloaded', () => {
+  test('records loadType when throttling occurs', () => {
+    const rateLimitConfig = { limitRate: true, loadLimit: { internal: 0.5 } }
+    const rl = new RateLimiting(rateLimitConfig, { info: jest.fn() } as any)
+    getCurrentNodeLoad.mockReturnValue({ internal: 0.9 })
+    getQueueLoad.mockReturnValue({})
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+    const result = rl.isOverloaded('tx1')
+    expect(result).toBe(true)
+    expect(monitorEvent).toHaveBeenCalledWith('loadRelated', 'txRejected:internal', 1, '')
+  })
+
+  test('does not record when under limit', () => {
+    const rateLimitConfig = { limitRate: true, loadLimit: { internal: 0.9 } }
+    const rl = new RateLimiting(rateLimitConfig, { info: jest.fn() } as any)
+    getCurrentNodeLoad.mockReturnValue({ internal: 0.5 })
+    getQueueLoad.mockReturnValue({})
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+    const result = rl.isOverloaded('tx2')
+    expect(result).toBe(false)
+    expect(monitorEvent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### **User description**
## Summary
- record max load type via monitorEvent when throttled
- cover rate-limiting metrics in tests

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Record `loadType` via `monitorEvent` when throttling occurs

- Add unit tests for rate-limiting metrics and throttling behavior

- Ensure fallback to `nestedCountersInstance.countEvent` if `monitorEvent` unavailable

- Improve observability of throttling events in rate limiting


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Record throttling events using monitorEvent with loadType</code></dd></summary>
<hr>

src/rate-limiting/index.ts

<li>Use <code>Context.shardus.monitorEvent</code> to record throttling by loadType<br> <li> Fallback to <code>nestedCountersInstance.countEvent</code> if <code>monitorEvent</code> is <br>unavailable<br> <li> Improves accuracy and observability of throttling events


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/500/files#diff-0bdeae4e6515620a184433c76b99bcdad10ce4a6042ff6ad05b68a0c336e6312">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add unit tests for rate-limiting throttling metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/unit/src/rate-limiting/index.test.ts

<li>Add unit tests for <code>RateLimiting.isOverloaded</code> throttling logic<br> <li> Test that <code>monitorEvent</code> is called with correct parameters when <br>overloaded<br> <li> Test that <code>monitorEvent</code> is not called when under limit<br> <li> Mock dependencies for isolated testing


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/500/files#diff-9c3a432c074cc7b7231d2d826b7d472d97c1906efd5f89f3a2c9cc7adb199824">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>