### PR TITLE
Fix cycle marker reporting

### DIFF
--- a/src/p2p/Join/routes.ts
+++ b/src/p2p/Join/routes.ts
@@ -51,7 +51,7 @@ const cycleMarkerRoute: P2P.P2PTypes.Route<Handler> = {
   method: 'GET',
   name: 'cyclemarker',
   handler: (_req, res) => {
-    const marker = CycleChain.newest ? CycleChain.newest.previous : '0'.repeat(64)
+    const marker = CycleChain.getCurrentCycleMarker() ?? '0'.repeat(64)
     res.json({ marker })
   },
 }

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -263,7 +263,7 @@ class Reporter {
       return
     }
     let appState = allZeroes64 // monititor server will set color based on partition report
-    const cycleMarker = CycleChain.newest.previous || '' // [TODO] Replace with cycle creator
+    const cycleMarker = CycleChain.getCurrentCycleMarker() || ''
     const cycleCounter = CycleChain.newest.counter
     const networkId = CycleChain.newest.networkId
     const desiredNodes = getDesiredCount()


### PR DESCRIPTION
### **User description**
## Summary
- update join cyclemarker route to use latest cycle marker
- have reporter emit the most recent cycle marker

## Testing
- `npm test`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Update cycle marker retrieval to use `getCurrentCycleMarker()`

- Ensure reporter emits the most recent cycle marker

- Improve accuracy of cycle marker reporting in join route


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.ts</strong><dd><code>Use getCurrentCycleMarker in cyclemarker route handler</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/p2p/Join/routes.ts

<li>Replace use of <code>CycleChain.newest.previous</code> with <br><code>CycleChain.getCurrentCycleMarker()</code><br> <li> Default to 64 zeroes if no marker is available


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/502/files#diff-930988f4462e59642535d5594f6894d8f4f13a7ad1bcebe2cc6c489da200627e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Reporter uses getCurrentCycleMarker for cycle marker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/reporter/index.ts

<li>Update reporter to use <code>CycleChain.getCurrentCycleMarker()</code> for cycle <br>marker<br> <li> Remove reliance on <code>CycleChain.newest.previous</code>


</details>


  </td>
  <td><a href="https://github.com/shardeum/core/pull/502/files#diff-3c0b343c8b320621fa514bd5ee3e66ae28f6f5c68facd9e933f819628672f139">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>