### PR TITLE
Add setup script for Node/Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ npm i @shardeum-foundation/core
 
 ## Installing and Building Locally
 
-Make sure you have Node.js and npm installed on your system. Run the following command to install the necessary dependencies:
+To quickly get a development environment with the correct Node.js version and Rust toolchain, run the setup script:
+
+```sh
+./scripts/setup.sh
+```
+
+If you prefer to install the prerequisites manually, make sure you have Node.js and npm installed on your system and run:
 
 ```sh
 npm install
 ```
 
-> Please note that you need to have the [Rust toolchain](https://opensource.com/article/20/3/rust-cargo) installed. We're working on a fix for this, but for now you'll need it. Specifically, `cargo` must be in your `PATH`.
+> The setup script installs the [Rust toolchain](https://opensource.com/article/20/3/rust-cargo) for you. If you skip the script you'll need to ensure `cargo` is in your `PATH`.
 
 For building the project, run the following command:
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NODE_VERSION="18.19.1"
+
+# Install build dependencies if apt-get is available
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y build-essential curl git python3
+fi
+
+# Install nvm if missing
+if [ ! -d "$HOME/.nvm" ]; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1090
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+# Install Rust if cargo is missing
+if ! command -v cargo >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source "$HOME/.cargo/env"
+fi
+
+# Install npm packages
+npm install
+
+cat <<INFO
+
+Setup complete. Node version: $(node --version)
+Rust version: $(rustc --version | cut -d' ' -f1-2)
+INFO


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install Node.js, Rust and dependencies
- reference the setup script from the README

## Testing
- `npm test`